### PR TITLE
Remove gRPC metapackage

### DIFF
--- a/DragonFruit.OnionFruit.Windows/DragonFruit.OnionFruit.Windows.csproj
+++ b/DragonFruit.OnionFruit.Windows/DragonFruit.OnionFruit.Windows.csproj
@@ -35,7 +35,6 @@
 
     <ItemGroup>
         <PackageReference Include="Google.Protobuf" Version="3.31.0" />
-        <PackageReference Include="Grpc" Version="2.46.6"/>
         <PackageReference Include="Grpc.Core.Api" Version="2.71.0" />
         <PackageReference Include="Grpc.Tools" Version="2.72.0" PrivateAssets="All" />
         <PackageReference Include="GrpcDotNetNamedPipes" Version="3.1.0" />


### PR DESCRIPTION
Turns out it wasn't even needed, blocked arm64 builds and sucked around 14mb of disk space for no reason...