### PR TITLE
Use WinHttpHandler on windows platforms

### DIFF
--- a/DragonFruit.OnionFruit.Windows/DragonFruit.OnionFruit.Windows.csproj
+++ b/DragonFruit.OnionFruit.Windows/DragonFruit.OnionFruit.Windows.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    
+
     <Import Project="..\DragonFruit.OnionFruit.Application.props" />
 
     <PropertyGroup>
@@ -19,6 +19,7 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0"/>
         <PackageReference Include="Serilog.Sinks.EventLog" Version="4.0.0"/>
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+        <PackageReference Include="System.Net.Http.WinHttpHandler" Version="9.0.7" />
     </ItemGroup>
 
     <ItemGroup>
@@ -33,7 +34,7 @@
     <ItemGroup>
         <TrimmerRootDescriptor Include="linker.xml" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <None Remove="nuget-license-sources.json"/>
     </ItemGroup>

--- a/DragonFruit.OnionFruit.Windows/Program.cs
+++ b/DragonFruit.OnionFruit.Windows/Program.cs
@@ -133,7 +133,7 @@ public static class Program
             services.AddSingleton<TorSession>();
             services.AddSingleton<OnionDbService>();
             services.AddSingleton<TransportManager>();
-            services.AddSingleton<ApiClient, OnionFruitClient>();
+            services.AddSingleton<ApiClient, WindowsApiClient>();
 
             services.AddSingleton(new WindowsAppInstanceManager(args));
 

--- a/DragonFruit.OnionFruit.Windows/WindowsApiClient.cs
+++ b/DragonFruit.OnionFruit.Windows/WindowsApiClient.cs
@@ -1,0 +1,28 @@
+﻿// OnionFruit Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under LGPL-3.0. Refer to the LICENCE file for more info
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using DragonFruit.OnionFruit.Services;
+
+namespace DragonFruit.OnionFruit.Windows
+{
+    public class WindowsApiClient : OnionFruitClient
+    {
+        public WindowsApiClient()
+        {
+            UserAgent = $"OnionFruitWin/v{Assembly.GetExecutingAssembly().GetName().Version?.ToString(3)}";
+            Handler = () => new WinHttpHandler
+            {
+                AutomaticDecompression = DecompressionMethods.All,
+                AutomaticRedirection = true,
+                CookieUsePolicy = CookieUsePolicy.IgnoreCookies,
+                SendTimeout = TimeSpan.FromSeconds(10),
+                ReceiveHeadersTimeout = TimeSpan.FromSeconds(15),
+                WindowsProxyUsePolicy = WindowsProxyUsePolicy.UseWinInetProxy
+            };
+        }
+    }
+}

--- a/DragonFruit.OnionFruit/Updater/VelopackFileDownloader.cs
+++ b/DragonFruit.OnionFruit/Updater/VelopackFileDownloader.cs
@@ -1,0 +1,84 @@
+﻿// OnionFruit Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under LGPL-3.0. Refer to the LICENCE file for more info
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using DragonFruit.Data;
+using Velopack.Sources;
+
+namespace DragonFruit.OnionFruit.Updater
+{
+    /// <summary>
+    /// A replacement to the <see cref="HttpClientFileDownloader"/>, leveraging the already-used <see cref="ApiClient"/> to perform network operations.
+    /// </summary>
+    public class VelopackFileDownloader(ApiClient client) : IFileDownloader
+    {
+        public async Task DownloadFile(string url, string targetFile, Action<int> progress, IDictionary<string, string> headers, double timeout, CancellationToken cancelToken)
+        {
+            using var fileRequest = PrepareRequest(url, headers);
+            using var fileDestinationStream = new FileStream(targetFile, FileMode.Create, FileAccess.Write, FileShare.None, 4096, FileOptions.Asynchronous);
+
+            using var timeoutCancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+            using var linkedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancelToken, timeoutCancellationSource.Token);
+
+            var progressReporter = new Progress<(long, long?)>(t => ReportProgress(t, progress));
+            var responseCode = await client.PerformDownload(fileRequest, fileDestinationStream, progressReporter, cancellationToken: linkedCancellationSource.Token).ConfigureAwait(false);
+
+            if (responseCode != HttpStatusCode.OK)
+            {
+                throw new HttpRequestException("Failed to download file", null, responseCode);
+            }
+
+            return;
+
+            static void ReportProgress((long Recieved, long? Total) bytes, Action<int> progressEvent)
+            {
+                if (bytes.Total.HasValue)
+                {
+                    var progress = (int)(bytes.Recieved / (double)bytes.Total.Value * 100);
+                    progressEvent.Invoke(progress);
+                }
+            }
+        }
+
+        public async Task<byte[]> DownloadBytes(string url, IDictionary<string, string> headers, double timeout)
+        {
+            using var cancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+            using var response = await client.PerformAsync(PrepareRequest(url, headers), cancellationToken.Token).ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadAsByteArrayAsync(cancellationToken.Token).ConfigureAwait(false);
+        }
+
+        public async Task<string> DownloadString(string url, IDictionary<string, string> headers, double timeout)
+        {
+            using var cancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+            using var response = await client.PerformAsync(PrepareRequest(url, headers), cancellationToken.Token).ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadAsStringAsync(cancellationToken.Token).ConfigureAwait(false);
+        }
+
+        private static HttpRequestMessage PrepareRequest(string url, IDictionary<string, string> headers)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            if (headers?.Count > 0)
+            {
+                foreach (var header in headers)
+                {
+                    request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            return request;
+        }
+    }
+}

--- a/DragonFruit.OnionFruit/Updater/VelopackUpdater.cs
+++ b/DragonFruit.OnionFruit/Updater/VelopackUpdater.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using DragonFruit.Data;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Velopack;
@@ -23,10 +24,10 @@ namespace DragonFruit.OnionFruit.Updater
         private OnionFruitUpdaterStatus _status;
         private int? _downloadProgress;
 
-        public VelopackUpdater(UpdateOptions options, ILogger<VelopackUpdater> logger)
+        public VelopackUpdater(UpdateOptions options, ApiClient client, ILogger<VelopackUpdater> logger)
         {
             _logger = logger;
-            _updateManager = new UpdateManager(new GithubSource("https://github.com/dragonfruitnetwork/onionfruit", null, true), options);
+            _updateManager = new UpdateManager(new GithubSource("https://github.com/dragonfruitnetwork/onionfruit", null, true, new VelopackFileDownloader(client)), options);
         }
 
         public OnionFruitUpdaterStatus Status


### PR DESCRIPTION
Switches from the default SocketsHttpHandler to the Windows-specific handler which should use the proxy settings we're setting as currently... we're not.

Also takes aim at velopack and reuses the ApiClient to improve performance. There's some bad practises including creating a `HttpClient` per-request (resolved by this) and reading in entire responses as strings (hard to work-around)