### PR TITLE
Add brotli-compressed onion.db

### DIFF
--- a/DragonFruit.OnionFruit/Database/OnionDbDownloadRequest.cs
+++ b/DragonFruit.OnionFruit/Database/OnionDbDownloadRequest.cs
@@ -10,9 +10,9 @@ namespace DragonFruit.OnionFruit.Database
     /// <summary>
     /// Represents a request to download the latest onion.db file
     /// </summary>
-    public partial class OnionDbDownloadRequest(DateTimeOffset? previousDatabaseVersion) : ApiRequest
+    public partial class OnionDbDownloadRequest(DateTimeOffset? previousDatabaseVersion, bool useBrotli) : ApiRequest
     {
-        public override string RequestPath => "https://onionfruit-api.dragonfruit.network/assets/onion.db";
+        public override string RequestPath => "https://onionfruit-api.dragonfruit.network/assets/onion.db" + (useBrotli ? ".br" : string.Empty);
 
         [RequestParameter(ParameterType.Header, "If-Modified-Since")]
         protected string PreviousDatabaseVersionString => previousDatabaseVersion?.ToString("R");


### PR DESCRIPTION
This should resolve #66 by taking the total download size from ~11mb to <2mb.

When combined with the WinHttpHandler changes in #69 performance issues should be totally resolved.