### PR TITLE
Replace Velopack downloader component

### DIFF
--- a/DragonFruit.OnionFruit/Updater/VelopackFileDownloader.cs
+++ b/DragonFruit.OnionFruit/Updater/VelopackFileDownloader.cs
@@ -1,0 +1,84 @@
+﻿// OnionFruit Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under LGPL-3.0. Refer to the LICENCE file for more info
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using DragonFruit.Data;
+using Velopack.Sources;
+
+namespace DragonFruit.OnionFruit.Updater
+{
+    /// <summary>
+    /// A replacement to the <see cref="HttpClientFileDownloader"/>, leveraging the already-used <see cref="ApiClient"/> to perform network operations.
+    /// </summary>
+    public class VelopackFileDownloader(ApiClient client) : IFileDownloader
+    {
+        public async Task DownloadFile(string url, string targetFile, Action<int> progress, IDictionary<string, string> headers, double timeout, CancellationToken cancelToken)
+        {
+            using var fileRequest = PrepareRequest(url, headers);
+            using var fileDestinationStream = new FileStream(targetFile, FileMode.Create, FileAccess.Write, FileShare.None, 4096, FileOptions.Asynchronous);
+
+            using var timeoutCancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+            using var linkedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancelToken, timeoutCancellationSource.Token);
+
+            var progressReporter = new Progress<(long, long?)>(t => ReportProgress(t, progress));
+            var responseCode = await client.PerformDownload(fileRequest, fileDestinationStream, progressReporter, cancellationToken: linkedCancellationSource.Token).ConfigureAwait(false);
+
+            if (responseCode != HttpStatusCode.OK)
+            {
+                throw new HttpRequestException("Failed to download file", null, responseCode);
+            }
+
+            return;
+
+            static void ReportProgress((long Recieved, long? Total) bytes, Action<int> progressEvent)
+            {
+                if (bytes.Total.HasValue)
+                {
+                    var progress = (int)(bytes.Recieved / (double)bytes.Total.Value * 100);
+                    progressEvent.Invoke(progress);
+                }
+            }
+        }
+
+        public async Task<byte[]> DownloadBytes(string url, IDictionary<string, string> headers, double timeout)
+        {
+            using var cancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+            using var response = await client.PerformAsync(PrepareRequest(url, headers), cancellationToken.Token).ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadAsByteArrayAsync(cancellationToken.Token).ConfigureAwait(false);
+        }
+
+        public async Task<string> DownloadString(string url, IDictionary<string, string> headers, double timeout)
+        {
+            using var cancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+            using var response = await client.PerformAsync(PrepareRequest(url, headers), cancellationToken.Token).ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadAsStringAsync(cancellationToken.Token).ConfigureAwait(false);
+        }
+
+        private static HttpRequestMessage PrepareRequest(string url, IDictionary<string, string> headers)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            if (headers?.Count > 0)
+            {
+                foreach (var header in headers)
+                {
+                    request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            return request;
+        }
+    }
+}

--- a/DragonFruit.OnionFruit/Updater/VelopackUpdater.cs
+++ b/DragonFruit.OnionFruit/Updater/VelopackUpdater.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using DragonFruit.Data;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Velopack;
@@ -23,10 +24,10 @@ namespace DragonFruit.OnionFruit.Updater
         private OnionFruitUpdaterStatus _status;
         private int? _downloadProgress;
 
-        public VelopackUpdater(UpdateOptions options, ILogger<VelopackUpdater> logger)
+        public VelopackUpdater(UpdateOptions options, ApiClient client, ILogger<VelopackUpdater> logger)
         {
             _logger = logger;
-            _updateManager = new UpdateManager(new GithubSource("https://github.com/dragonfruitnetwork/onionfruit", null, true), options);
+            _updateManager = new UpdateManager(new GithubSource("https://github.com/dragonfruitnetwork/onionfruit", null, true, new VelopackFileDownloader(client)), options);
         }
 
         public OnionFruitUpdaterStatus Status


### PR DESCRIPTION
The current velopack downloader system spins up a HttpClient per-request and has some questionable methods of processing data that don't align with how DragonFruit.Data works.

This adds a custom IFileDownloader that uses the already-existing `ApiClient` infrastructure that powers the rest of the networking in the app, and with #69 should make the updater proxy-aware.