### PR TITLE
Fix about page performance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageVersion Include="AppServiceSharp" Version="1.0.1" />
     <PackageVersion Include="Avalonia" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
     <PackageVersion Include="Avalonia.Desktop" Version="11.3.12" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.12" />
     <PackageVersion Include="Avalonia.ReactiveUI" Version="11.3.8" />

--- a/DragonFruit.OnionFruit/DragonFruit.OnionFruit.csproj
+++ b/DragonFruit.OnionFruit/DragonFruit.OnionFruit.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" />
-    <PackageReference Include="Avalonia.Controls.ItemsRepeater" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.ReactiveUI" />
     <PackageReference Include="DragonFruit.Data" />

--- a/DragonFruit.OnionFruit/ViewModels/AboutPageTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/AboutPageTabViewModel.cs
@@ -28,8 +28,6 @@ namespace DragonFruit.OnionFruit.ViewModels
 
         private readonly ObservableAsPropertyHelper<string> _updateProgress;
 
-        private IEnumerable<NugetPackageLicenseInfo> _packages;
-
         public AboutPageTabViewModel(IOnionFruitUpdater updater, ILogger<AboutPageTabViewModel> logger)
         {
             _logger = logger;
@@ -68,7 +66,7 @@ namespace DragonFruit.OnionFruit.ViewModels
 
             ManualUpdateTrigger = ReactiveCommand.Create(updater.TriggerUpdateCheck, canCheckForUpdates).DisposeWith(_disposables);
 
-            _ = ReadPackageLicenseFile();
+            Task.Run(ReadPackageLicenseFile);
         }
 
         public IconSource UpdaterIcon => App.GetIcon(LucideIconNames.RefreshCw);
@@ -78,16 +76,14 @@ namespace DragonFruit.OnionFruit.ViewModels
 
         public IEnumerable<NugetPackageLicenseInfo> Packages
         {
-            get => _packages;
-            set => this.RaiseAndSetIfChanged(ref _packages, value);
+            get;
+            set => this.RaiseAndSetIfChanged(ref field, value);
         }
 
         public ICommand ManualUpdateTrigger { get; }
 
         private async Task ReadPackageLicenseFile()
         {
-            await Task.Yield();
-
             var filePath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location), "nuget-licenses.json");
 
             if (!File.Exists(filePath))

--- a/DragonFruit.OnionFruit/Views/Settings/AboutPageTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/AboutPageTabView.axaml
@@ -29,59 +29,54 @@
         </controls:SettingsExpander>
 
         <controls:SettingsExpander Description="Licenses" IconSource="{Binding LicensesIcon, Mode=OneTime}">
-            <StackPanel Orientation="Vertical" Margin="0, 15">
-                <ItemsRepeater ItemsSource="{Binding Packages}">
-                    <ItemsRepeater.Layout>
-                        <StackLayout/>
-                    </ItemsRepeater.Layout>
-                    <ItemsRepeater.ItemTemplate>
-                        <DataTemplate DataType="models:NugetPackageLicenseInfo">
-                            <StackPanel Orientation="Vertical">
-                                <DockPanel>
-                                    <StackPanel Orientation="Horizontal" Spacing="10" DockPanel.Dock="Right">
-                                        <TextBlock TextTrimming="WordEllipsis" VerticalAlignment="Center" Text="{Binding Copyright}" />
-                                        <Border Height="20"
-                                                Width="20"
-                                                Margin="10,0,0,0"
-                                                BorderThickness="0"
-                                                Background="Transparent"
-                                                ToolTip.Tip="{Binding License}"
-                                                ToolTip.HorizontalOffset="-15"
-                                                ToolTip.VerticalOffset="0"
-                                                ToolTip.Placement="Left">
-                                            <lucideAvalonia:Lucide Width="20"
-                                                                   Height="20"
-                                                                   Icon="Scale"
-                                                                   StrokeBrush="LimeGreen"
-                                                                   VerticalAlignment="Center"/>
-                                        </Border>
+            <ItemsControl ItemsSource="{Binding Packages}" Margin="0, 15">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="models:NugetPackageLicenseInfo">
+                        <StackPanel Orientation="Vertical">
+                            <DockPanel>
+                                <StackPanel Orientation="Horizontal" Spacing="10" DockPanel.Dock="Right">
+                                    <TextBlock TextTrimming="WordEllipsis" VerticalAlignment="Center" Text="{Binding Copyright}" />
+                                    <Border Height="20"
+                                            Width="20"
+                                            Margin="10,0,0,0"
+                                            BorderThickness="0"
+                                            Background="Transparent"
+                                            ToolTip.Tip="{Binding License}"
+                                            ToolTip.HorizontalOffset="-15"
+                                            ToolTip.VerticalOffset="0"
+                                            ToolTip.Placement="Left">
+                                        <lucideAvalonia:Lucide Width="20"
+                                                               Height="20"
+                                                               Icon="Scale"
+                                                               StrokeBrush="LimeGreen"
+                                                               VerticalAlignment="Center"/>
+                                    </Border>
 
-                                    </StackPanel>
+                                </StackPanel>
 
-                                    <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
-                                        <Label VerticalAlignment="Center" Content="{Binding PackageId}" FontWeight="SemiBold" />
-                                        <Label VerticalAlignment="Center" Content="{Binding PackageVersion, StringFormat='v{0}'}" Foreground="LightGray" />
+                                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                                    <Label VerticalAlignment="Center" Content="{Binding PackageId}" FontWeight="SemiBold" />
+                                    <Label VerticalAlignment="Center" Content="{Binding PackageVersion, StringFormat='v{0}'}" Foreground="LightGray" />
 
-                                        <Button Margin="5,0,0,0"
-                                                VerticalAlignment="Center"
-                                                BorderBrush="{x:Null}"
-                                                Background="{x:Null}" 
-                                                IsVisible="{Binding HasProjectUrl}"
-                                                Command="{Binding OpenProjectWebsite}"
-                                                ToolTip.Tip="Open Project Website"
-                                                ToolTip.Placement="Right"
-                                                ToolTip.VerticalOffset="0"
-                                                ToolTip.HorizontalOffset="5">
-                                            <lucideAvalonia:Lucide Icon="ExternalLink" Height="15" Width="15" StrokeBrush="LightGray"/>
-                                        </Button>
-                                    </StackPanel>
-                                </DockPanel>
-                                <Border Height="1" Background="Gray" Margin="0, 15" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </ItemsRepeater.ItemTemplate>
-                </ItemsRepeater>
-            </StackPanel>
+                                    <Button Margin="5,0,0,0"
+                                            VerticalAlignment="Center"
+                                            BorderBrush="{x:Null}"
+                                            Background="{x:Null}" 
+                                            IsVisible="{Binding HasProjectUrl}"
+                                            Command="{Binding OpenProjectWebsite}"
+                                            ToolTip.Tip="Open Project Website"
+                                            ToolTip.Placement="Right"
+                                            ToolTip.VerticalOffset="0"
+                                            ToolTip.HorizontalOffset="5">
+                                        <lucideAvalonia:Lucide Icon="ExternalLink" Height="15" Width="15" StrokeBrush="LightGray"/>
+                                    </Button>
+                                </StackPanel>
+                            </DockPanel>
+                            <Border Height="1" Background="Gray" Margin="0, 15" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </controls:SettingsExpander>
     </StackPanel>
 </UserControl>

--- a/DragonFruit.OnionFruit/Views/Settings/BridgeSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/BridgeSettingsTabView.axaml
@@ -63,11 +63,13 @@
                         </TextBlock>
                     </StackPanel>
                     
-                    <controls:ItemsRepeater ItemsSource="{Binding CurrentBridgeLines}">
-                        <controls:ItemsRepeater.Layout>
-                            <controls:StackLayout Spacing="15"/>
-                        </controls:ItemsRepeater.Layout>
-                        <controls:ItemsRepeater.ItemTemplate>
+                    <ItemsControl ItemsSource="{Binding CurrentBridgeLines}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Spacing="15"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
                             <DataTemplate DataType="system:String">
                                 <Grid ColumnDefinitions="*, 10, 30" VerticalAlignment="Center">
                                     <TextBlock Grid.Column="0" 
@@ -75,13 +77,13 @@
                                                Text="{Binding}"
                                                VerticalAlignment="Center"
                                                FontFamily="{StaticResource JetBrainsMono}"/>
-                                    <Button Grid.Column="2" Command="{Binding $parent[controls:ItemsRepeater].((viewModels:BridgeSettingsTabViewModel)DataContext).RemoveBridgeLine}" CommandParameter="{Binding}">
+                                    <Button Grid.Column="2" Command="{Binding $parent[ItemsControl].((viewModels:BridgeSettingsTabViewModel)DataContext).RemoveBridgeLine}" CommandParameter="{Binding}">
                                         <lucideAvalonia:Lucide Icon="Trash" StrokeBrush="OrangeRed" Height="15" Width="15" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                     </Button>
                                 </Grid>
                             </DataTemplate>
-                        </controls:ItemsRepeater.ItemTemplate>
-                    </controls:ItemsRepeater>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </StackPanel>
             </controls:SettingsExpander>
         </StackPanel>

--- a/DragonFruit.OnionFruit/Views/Settings/ConnectionSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/ConnectionSettingsTabView.axaml
@@ -129,21 +129,23 @@
                 <controls1:SwitchingControl Switch="{Binding ShouldShowFirewallPortList}">
                     <controls1:SwitchingControl.SwitchTrue>
                         <DataTemplate DataType="viewModels:ConnectionSettingsTabViewModel">
-                            <controls:ItemsRepeater DockPanel.Dock="Right" ItemsSource="{Binding AllowedFirewallPorts}" HorizontalAlignment="Right">
-                                <controls:ItemsRepeater.Layout>
-                                    <controls:FlowLayout Orientation="Horizontal" LineAlignment="End" MinColumnSpacing="10" MinRowSpacing="10"/>
-                                </controls:ItemsRepeater.Layout>
-                                <controls:ItemsRepeater.ItemTemplate>
+                            <ItemsControl DockPanel.Dock="Right" ItemsSource="{Binding AllowedFirewallPorts}" HorizontalAlignment="Right">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel Orientation="Horizontal" HorizontalAlignment="Right"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
                                     <DataTemplate DataType="system:UInt32">
-                                        <Button MinHeight="35" Command="{Binding $parent[controls:ItemsRepeater].((viewModels:ConnectionSettingsTabViewModel)DataContext).RemoveFirewallPort}" CommandParameter="{Binding}">
+                                        <Button MinHeight="35" Margin="5" Command="{Binding $parent[ItemsControl].((viewModels:ConnectionSettingsTabViewModel)DataContext).RemoveFirewallPort}" CommandParameter="{Binding}">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
                                                 <Label Content="{Binding StringFormat=':{0}'}"/>
                                                 <lucideAvalonia:Lucide Icon="Trash" StrokeBrush="OrangeRed" Height="13" Width="13" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
                                     </DataTemplate>
-                                </controls:ItemsRepeater.ItemTemplate>
-                            </controls:ItemsRepeater>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
                         </DataTemplate>
                     </controls1:SwitchingControl.SwitchTrue>
                     <controls1:SwitchingControl.SwitchFalse>


### PR DESCRIPTION
Two fixes that are in the about page area:

- Fixes the initial freezing by forcing the json to load on a different thread
- Swaps ItemRepeater for ItemsControl (it doesn't require a view change to trigger a re-render)
  - Applied the same change to other areas that can support it