### PR TITLE
Upgrade to Avalonia v12

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,45 +1,48 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-        <NoWarn>$(NoWarn);NU1507</NoWarn>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="AppServiceSharp" Version="1.0.1" />
-        <PackageVersion Include="Avalonia" Version="12.0.4" />
-        <PackageVersion Include="Avalonia.Desktop" Version="12.0.4" />
-        <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-        <PackageVersion Include="DiscordRichPresence" Version="1.6.1.70" />
-        <PackageVersion Include="DragonFruit.Data" Version="4.1.2" />
-        <PackageVersion Include="DragonFruit.Data.Roslyn" Version="4.1.2" />
-        <PackageVersion Include="DragonFruit.LucideAvalonia" Version="2.0.0-beta" />
-        <PackageVersion Include="DragonFruit.OnionFruit.Native.osx" Version="15.0.15" />
-        <PackageVersion Include="DragonFruit.OnionFruit.Native.win" Version="15.0.15" />
-        <PackageVersion Include="FluentAvaloniaUI" Version="3.0.0-preview4" />
-        <PackageVersion Include="Google.Protobuf" Version="3.35.0" />
-        <PackageVersion Include="Grpc.Core.Api" Version="2.80.0" />
-        <PackageVersion Include="Grpc.Tools" Version="2.81.0" />
-        <PackageVersion Include="GrpcDotNetNamedPipes" Version="3.1.0" />
-        <PackageVersion Include="LucideAvalonia" Version="1.6.2" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-        <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.275" />
-        <PackageVersion Include="Neovolve.Logging.Xunit" Version="6.3.0" />
-        <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-        <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
-        <PackageVersion Include="Sentry.Serilog" Version="6.6.0" />
-        <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
-        <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-        <PackageVersion Include="Serilog.Sinks.EventLog" Version="4.0.0" />
-        <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-        <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.11" />
-        <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="10.0.8" />
-        <PackageVersion Include="Velopack" Version="0.0.1298" />
-        <PackageVersion Include="WmiLight" Version="7.2.0" />
-        <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.0.1" />
-        <PackageVersion Include="xunit" Version="2.9.3" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    </ItemGroup>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="AppServiceSharp" Version="1.0.1" />
+    <PackageVersion Include="Avalonia" Version="12.0.4" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="DiscordRichPresence" Version="1.6.1.70" />
+    <PackageVersion Include="DragonFruit.Data" Version="4.1.2" />
+    <PackageVersion Include="DragonFruit.Data.Roslyn" Version="4.1.2" />
+    <PackageVersion Include="DragonFruit.LucideAvalonia" Version="2.0.0-beta" />
+    <PackageVersion Include="DragonFruit.OnionFruit.Native.osx" Version="15.0.15" />
+    <PackageVersion Include="DragonFruit.OnionFruit.Native.win" Version="15.0.15" />
+    <PackageVersion Include="FluentAvaloniaUI" Version="3.0.0-preview4" />
+    <PackageVersion Include="Google.Protobuf" Version="3.35.0" />
+    <PackageVersion Include="Grpc.Core.Api" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.81.0" />
+    <PackageVersion Include="GrpcDotNetNamedPipes" Version="3.1.0" />
+    <PackageVersion Include="LucideAvalonia" Version="1.6.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.275" />
+    <PackageVersion Include="Neovolve.Logging.Xunit" Version="6.3.0" />
+    <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
+    <PackageVersion Include="Sentry.Serilog" Version="6.6.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="Serilog.Sinks.EventLog" Version="4.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.11" />
+    <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="10.0.8" />
+    <PackageVersion Include="Velopack" Version="0.0.1298" />
+    <PackageVersion Include="WmiLight" Version="7.2.0" />
+    <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.0.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,45 +1,45 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <NoWarn>$(NoWarn);NU1507</NoWarn>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="AppServiceSharp" Version="1.0.1" />
-    <PackageVersion Include="Avalonia" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.17" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="DiscordRichPresence" Version="1.6.1.70" />
-    <PackageVersion Include="DragonFruit.Data" Version="4.1.2" />
-    <PackageVersion Include="DragonFruit.Data.Roslyn" Version="4.1.2" />
-    <PackageVersion Include="DragonFruit.OnionFruit.Native.osx" Version="15.0.15" />
-    <PackageVersion Include="DragonFruit.OnionFruit.Native.win" Version="15.0.15" />
-    <PackageVersion Include="FluentAvaloniaUI" Version="2.5.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.35.0" />
-    <PackageVersion Include="Grpc.Core.Api" Version="2.80.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.81.0" />
-    <PackageVersion Include="GrpcDotNetNamedPipes" Version="3.1.0" />
-    <PackageVersion Include="LucideAvalonia" Version="1.6.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.275" />
-    <PackageVersion Include="Neovolve.Logging.Xunit" Version="6.3.0" />
-    <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.13" />
-    <PackageVersion Include="Sentry.Serilog" Version="6.6.0" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageVersion Include="Serilog.Sinks.EventLog" Version="4.0.0" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="11.3.9.2" />
-    <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="10.0.8" />
-    <PackageVersion Include="Velopack" Version="0.0.1298" />
-    <PackageVersion Include="WmiLight" Version="7.2.0" />
-    <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="11.3.9.5" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-  </ItemGroup>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+        <NoWarn>$(NoWarn);NU1507</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="AppServiceSharp" Version="1.0.1" />
+        <PackageVersion Include="Avalonia" Version="12.0.4" />
+        <PackageVersion Include="Avalonia.Desktop" Version="12.0.4" />
+        <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+        <PackageVersion Include="DiscordRichPresence" Version="1.6.1.70" />
+        <PackageVersion Include="DragonFruit.Data" Version="4.1.2" />
+        <PackageVersion Include="DragonFruit.Data.Roslyn" Version="4.1.2" />
+        <PackageVersion Include="DragonFruit.LucideAvalonia" Version="2.0.0-beta" />
+        <PackageVersion Include="DragonFruit.OnionFruit.Native.osx" Version="15.0.15" />
+        <PackageVersion Include="DragonFruit.OnionFruit.Native.win" Version="15.0.15" />
+        <PackageVersion Include="FluentAvaloniaUI" Version="3.0.0-preview4" />
+        <PackageVersion Include="Google.Protobuf" Version="3.35.0" />
+        <PackageVersion Include="Grpc.Core.Api" Version="2.80.0" />
+        <PackageVersion Include="Grpc.Tools" Version="2.81.0" />
+        <PackageVersion Include="GrpcDotNetNamedPipes" Version="3.1.0" />
+        <PackageVersion Include="LucideAvalonia" Version="1.6.2" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.275" />
+        <PackageVersion Include="Neovolve.Logging.Xunit" Version="6.3.0" />
+        <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
+        <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
+        <PackageVersion Include="Sentry.Serilog" Version="6.6.0" />
+        <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+        <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+        <PackageVersion Include="Serilog.Sinks.EventLog" Version="4.0.0" />
+        <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+        <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.11" />
+        <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="10.0.8" />
+        <PackageVersion Include="Velopack" Version="0.0.1298" />
+        <PackageVersion Include="WmiLight" Version="7.2.0" />
+        <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.0.1" />
+        <PackageVersion Include="xunit" Version="2.9.3" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="DragonFruit.LucideAvalonia" Version="2.0.0-beta" />
     <PackageVersion Include="DragonFruit.OnionFruit.Native.osx" Version="15.0.15" />
     <PackageVersion Include="DragonFruit.OnionFruit.Native.win" Version="15.0.15" />
-    <PackageVersion Include="FluentAvaloniaUI" Version="3.0.0-preview4" />
+    <PackageVersion Include="FluentAvaloniaUI" Version="3.0.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.35.0" />
     <PackageVersion Include="Grpc.Core.Api" Version="2.80.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.81.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,7 +36,7 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.EventLog" Version="4.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.11" />
+    <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.13" />
     <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="10.0.8" />
     <PackageVersion Include="Velopack" Version="0.0.1298" />
     <PackageVersion Include="WmiLight" Version="7.2.0" />

--- a/DragonFruit.OnionFruit.Core.Windows/AssemblyAttributes.cs
+++ b/DragonFruit.OnionFruit.Core.Windows/AssemblyAttributes.cs
@@ -3,4 +3,4 @@
 
 using System.Runtime.Versioning;
 
-[assembly: SupportedOSPlatform("windows")]
+[assembly: SupportedOSPlatform("windows10.0")]

--- a/DragonFruit.OnionFruit.MacOS/ViewModels/ServiceManagementTabViewModel.cs
+++ b/DragonFruit.OnionFruit.MacOS/ViewModels/ServiceManagementTabViewModel.cs
@@ -39,9 +39,9 @@ namespace DragonFruit.OnionFruit.MacOS.ViewModels
             ServiceStatus = _daemonService?.Status;
         }
 
-        public IconSource ServiceInfoIcon => App.GetIcon(LucideIconNames.Cog);
-        public IconSource ServiceStatusIcon => App.GetIcon(LucideIconNames.Bolt);
-        public IconSource ServiceAdministrationIcon => App.GetIcon(LucideIconNames.Wrench);
+        public FAIconSource ServiceInfoIcon => App.GetIcon(LucideIconNames.Cog);
+        public FAIconSource ServiceStatusIcon => App.GetIcon(LucideIconNames.Bolt);
+        public FAIconSource ServiceAdministrationIcon => App.GetIcon(LucideIconNames.Wrench);
 
         public AppServiceStatus? ServiceStatus
         {

--- a/DragonFruit.OnionFruit.MacOS/Views/ServiceManagementTabView.axaml
+++ b/DragonFruit.OnionFruit.MacOS/Views/ServiceManagementTabView.axaml
@@ -9,11 +9,11 @@
              x:DataType="viewModels:ServiceManagementTabViewModel"
              x:Class="DragonFruit.OnionFruit.MacOS.Views.ServiceManagementTabView">
         <StackPanel DockPanel.Dock="Bottom" Orientation="Vertical" MaxWidth="1400" Spacing="10">
-            <controls:NavigationViewItemHeader Content="macOS Service Management" />
+            <controls:FANavigationViewItemHeader Content="macOS Service Management" />
 
             <StackPanel Orientation="Vertical" Spacing="10" Margin="15, 20">
-                <controls:SettingsExpander IconSource="{Binding ServiceInfoIcon, Mode=OneTime}" Description="OnionFruit™ requires a service on macOS to change system settings. Use the options on this page to manage the service installation.">
-                    <controls:SettingsExpander.Resources>
+                <controls:FASettingsExpander IconSource="{Binding ServiceInfoIcon, Mode=OneTime}" Description="OnionFruit™ requires a service on macOS to change system settings. Use the options on this page to manage the service installation.">
+                    <controls:FASettingsExpander.Resources>
                         <ResourceDictionary>
                             <ResourceDictionary.MergedDictionaries>
                                 <ResourceDictionary>
@@ -21,15 +21,15 @@
                                 </ResourceDictionary>
                             </ResourceDictionary.MergedDictionaries>
                         </ResourceDictionary>
-                    </controls:SettingsExpander.Resources>
-                    <controls:SettingsExpander.Header>
+                    </controls:FASettingsExpander.Resources>
+                    <controls:FASettingsExpander.Header>
                         <TextBlock Text="Service Info" Margin="{OnPlatform Default='0,0,0,5', Windows='0'}" FontSize="16" Foreground="White"/>
-                    </controls:SettingsExpander.Header>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Header>
+                </controls:FASettingsExpander>
 
                 
-                <controls:SettingsExpander Description="Status" IconSource="{Binding ServiceStatusIcon, Mode=OneTime}" Footer="{Binding ServiceStatusContent}">
-                    <controls:SettingsExpander.FooterTemplate>
+                <controls:FASettingsExpander Description="Status" IconSource="{Binding ServiceStatusIcon, Mode=OneTime}" Footer="{Binding ServiceStatusContent}">
+                    <controls:FASettingsExpander.FooterTemplate>
                         <DataTemplate DataType="viewModels:ServiceStatusViewModel">
                             <StackPanel Orientation="Horizontal" Spacing="15" Margin="0, 15">
                                 <Ellipse VerticalAlignment="Center" Fill="{Binding IconColor, Mode=OneWay}" Width="15" Height="15"/>
@@ -42,17 +42,17 @@
                                         Command="{Binding  $parent[UserControl].((viewModels:ServiceManagementTabViewModel)DataContext).RegisterService}"/>
                             </StackPanel>
                         </DataTemplate>
-                    </controls:SettingsExpander.FooterTemplate>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.FooterTemplate>
+                </controls:FASettingsExpander>
 
-                <controls:SettingsExpander Description="Service Administration" IconSource="{Binding ServiceAdministrationIcon, Mode=OneTime}" IsVisible="{Binding !ServiceStatusContent.ShowInstallButton}">
-                    <controls:SettingsExpander.Footer>
+                <controls:FASettingsExpander Description="Service Administration" IconSource="{Binding ServiceAdministrationIcon, Mode=OneTime}" IsVisible="{Binding !ServiceStatusContent.ShowInstallButton}">
+                    <controls:FASettingsExpander.Footer>
                         <StackPanel Orientation="Horizontal" Spacing="15" Margin="0, 15">
                             <Button Content="Remove Service" Command="{Binding UnregisterService}"/>
                             <Button Content="Open System Settings" Command="{Binding OpenSystemSettings}"/>
                         </StackPanel>
-                    </controls:SettingsExpander.Footer>
-                </controls:SettingsExpander>
+                    </controls:FASettingsExpander.Footer>
+                </controls:FASettingsExpander>
             </StackPanel>
         </StackPanel>
 </UserControl>

--- a/DragonFruit.OnionFruit.MacOS/Views/ServiceManagementTabView.axaml
+++ b/DragonFruit.OnionFruit.MacOS/Views/ServiceManagementTabView.axaml
@@ -27,7 +27,6 @@
                     </controls:FASettingsExpander.Header>
                 </controls:FASettingsExpander>
 
-                
                 <controls:FASettingsExpander Description="Status" IconSource="{Binding ServiceStatusIcon, Mode=OneTime}" Footer="{Binding ServiceStatusContent}">
                     <controls:FASettingsExpander.FooterTemplate>
                         <DataTemplate DataType="viewModels:ServiceStatusViewModel">

--- a/DragonFruit.OnionFruit.MacOS/linker.xml
+++ b/DragonFruit.OnionFruit.MacOS/linker.xml
@@ -3,7 +3,7 @@
     <assembly fullname="DragonFruit.OnionFruit"/>
     <assembly fullname="DragonFruit.OnionFruit.Core"/>
     <assembly fullname="DragonFruit.OnionFruit.Core.MacOS"/>
-    
+
     <!-- DragonFruit.OnionFruit.MacOS -->
     <assembly fullname="onionfruit"/>
 </linker>

--- a/DragonFruit.OnionFruit.Windows/Rpc/onionrpc.proto
+++ b/DragonFruit.OnionFruit.Windows/Rpc/onionrpc.proto
@@ -11,7 +11,7 @@ service OnionRpc {
 message SecondInstanceLaunchedResponse {
   // whether the receiver of this message should close
   bool shouldClose = 1;
-  
+
   // optional PID to wait for before continuing
   optional int32 waitForPidExit = 2; 
 }

--- a/DragonFruit.OnionFruit/App.axaml
+++ b/DragonFruit.OnionFruit/App.axaml
@@ -9,7 +9,7 @@
     <Application.Styles>
         <styling:FluentAvaloniaTheme UseSystemFontOnWindows="True" CustomAccentColor="#c71585" />
         <onionFruit:NonWindowsFluentAvaloniaAdjustments />
-        
+
         <Style Selector="controls|FANavigationViewItemHeader">
             <Setter Property="VerticalAlignment" Value="Top"/>
             <Setter Property="FontSize" Value="24"/>

--- a/DragonFruit.OnionFruit/App.axaml
+++ b/DragonFruit.OnionFruit/App.axaml
@@ -10,7 +10,7 @@
         <styling:FluentAvaloniaTheme UseSystemFontOnWindows="True" CustomAccentColor="#c71585" />
         <onionFruit:NonWindowsFluentAvaloniaAdjustments />
         
-        <Style Selector="controls|NavigationViewItemHeader">
+        <Style Selector="controls|FANavigationViewItemHeader">
             <Setter Property="VerticalAlignment" Value="Top"/>
             <Setter Property="FontSize" Value="24"/>
             <Setter Property="Margin" Value="{DynamicResource SettingsTabHeaderMargin}"/>

--- a/DragonFruit.OnionFruit/App.axaml.cs
+++ b/DragonFruit.OnionFruit/App.axaml.cs
@@ -308,7 +308,7 @@ namespace DragonFruit.OnionFruit
             }
         }
 
-        public static IconSource GetIcon(LucideIconNames icon, IImmutableSolidColorBrush brush = null, double thickness = 1.5)
+        public static FAIconSource GetIcon(LucideIconNames icon, IImmutableSolidColorBrush brush = null, double thickness = 1.5)
         {
             var resource = Instance.Resources.MergedDictionaries.FirstOrDefault() as ResourceDictionary;
             var drawingImage = resource?[icon.ToString()] as DrawingImage;
@@ -323,7 +323,7 @@ namespace DragonFruit.OnionFruit
                 }
             }
 
-            return new ImageIconSource
+            return new FAImageIconSource
             {
                 Source = drawingImage
             };

--- a/DragonFruit.OnionFruit/App.axaml.cs
+++ b/DragonFruit.OnionFruit/App.axaml.cs
@@ -234,14 +234,7 @@ namespace DragonFruit.OnionFruit
                         return;
                     }
 
-                    Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        var trayIcon = TrayIcon.GetIcons(this)?.SingleOrDefault();
-                        if (trayIcon != null)
-                        {
-                            trayIcon.IsVisible = true;
-                        }
-                    });
+                    Dispatcher.UIThread.InvokeAsync(() => TrayIcon.GetIcons(this)?.SingleOrDefault()?.IsVisible = true);
                 }, TaskContinuationOptions.OnlyOnFaulted);
 
                 await waitTask.ConfigureAwait(false);
@@ -273,11 +266,7 @@ namespace DragonFruit.OnionFruit
                 window.ShowInTaskbar = true;
                 window.IsVisible = true;
 
-                var trayIcon = TrayIcon.GetIcons(this)?.SingleOrDefault();
-                if (trayIcon != null)
-                {
-                    trayIcon.IsVisible = false;
-                }
+                TrayIcon.GetIcons(this)?.SingleOrDefault()?.IsVisible = false;
 
                 window.Activate();
             });

--- a/DragonFruit.OnionFruit/Configuration/OnionFruitSettingsStore.cs
+++ b/DragonFruit.OnionFruit/Configuration/OnionFruitSettingsStore.cs
@@ -269,7 +269,11 @@ namespace DragonFruit.OnionFruit.Configuration
         private void RegisterCollection<T, TStored>(OnionFruitSetting key, IEnumerable<T> defaultValue, Func<OnionFruitConfigFile, RepeatedField<TStored>> rfAccessor, Func<TStored, T> rfConversion, Func<T, TStored> rfConversionRev)
         {
             var observer = RegisterCollection<T>(key, out var list);
-            _storeCollections[key] = new SettingsCollectionEntry(c => list.AddRange(rfAccessor.Invoke(c).Select(rfConversion)), c =>
+            _storeCollections[key] = new SettingsCollectionEntry(c => list.Edit(inner =>
+            {
+                inner.Clear();
+                inner.AddRange(rfAccessor.Invoke(c).Select(rfConversion));
+            }), c =>
             {
                 var collection = rfAccessor.Invoke(c);
 
@@ -277,10 +281,6 @@ namespace DragonFruit.OnionFruit.Configuration
                 collection.AddRange(defaultValue.Select(rfConversionRev));
             });
 
-            if (defaultValue.Any())
-            {
-                observer = observer.SkipInitial();
-            }
 
             observer.ObserveOn(RxSchedulers.TaskpoolScheduler).Subscribe(cs =>
                 {

--- a/DragonFruit.OnionFruit/Configuration/OnionFruitSettingsStore.cs
+++ b/DragonFruit.OnionFruit/Configuration/OnionFruitSettingsStore.cs
@@ -288,8 +288,15 @@ namespace DragonFruit.OnionFruit.Configuration
 
                     using (list.Connect().Bind(out var clonedList).Subscribe())
                     {
+                        var newValues = clonedList.Select(rfConversionRev).ToArray();
+
+                        if (collection.SequenceEqual(newValues))
+                        {
+                            return;
+                        }
+
                         collection.Clear();
-                        collection.AddRange(clonedList.Select(rfConversionRev).ToList());
+                        collection.AddRange(newValues);
 
                         _logger.LogInformation("Configuration collection {key} updated ({newVals})", key, string.Join(", ", clonedList.AsEnumerable()));
                     }

--- a/DragonFruit.OnionFruit/Database/OnionDbService.cs
+++ b/DragonFruit.OnionFruit/Database/OnionDbService.cs
@@ -40,8 +40,6 @@ namespace DragonFruit.OnionFruit.Database
         private CancellationTokenSource _cancellation;
 
         private OnionDb _currentDb;
-        private DatabaseState _state;
-        private IReadOnlyCollection<TorNodeCountry> _countries;
 
         private readonly ApiClient _client;
         private readonly ILogger<OnionDbService> _logger;
@@ -74,22 +72,22 @@ namespace DragonFruit.OnionFruit.Database
 
         public DatabaseState State
         {
-            get => _state;
+            get;
             private set
             {
-                if (_state == value) return;
+                if (field == value) return;
 
-                _state = value;
+                field = value;
                 StateChanged?.Invoke(this, value);
             }
         }
 
         public IReadOnlyCollection<TorNodeCountry> Countries
         {
-            get => _countries;
+            get;
             private set
             {
-                _countries = value;
+                field = value;
                 CountriesChanged?.Invoke(this, value);
             }
         }

--- a/DragonFruit.OnionFruit/DragonFruit.OnionFruit.csproj
+++ b/DragonFruit.OnionFruit/DragonFruit.OnionFruit.csproj
@@ -14,13 +14,13 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="DiscordRichPresence" />
     <PackageReference Include="DragonFruit.Data" />
     <PackageReference Include="DragonFruit.Data.Roslyn" />
-    <PackageReference Include="DiscordRichPresence" />
+    <PackageReference Include="DragonFruit.LucideAvalonia" />
     <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="all" />
-    <PackageReference Include="LucideAvalonia" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Nito.AsyncEx.Coordination" />

--- a/DragonFruit.OnionFruit/DragonFruit.OnionFruit.csproj
+++ b/DragonFruit.OnionFruit/DragonFruit.OnionFruit.csproj
@@ -27,8 +27,6 @@
     <PackageReference Include="ReactiveUI.Avalonia" />
     <PackageReference Include="Svg.Controls.Skia.Avalonia" />
     <PackageReference Include="Velopack" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" />
   </ItemGroup>
 

--- a/DragonFruit.OnionFruit/Models/TorSession.cs
+++ b/DragonFruit.OnionFruit/Models/TorSession.cs
@@ -33,7 +33,6 @@ namespace DragonFruit.OnionFruit.Models
 
         private bool _bootstrapped;
         private TorProcess _process;
-        private TorSessionState _state = TorSessionState.Disconnected;
 
         private IPAddress[] _activeDnsServers;
         private NetworkProxy[] _activeProxies;
@@ -48,15 +47,15 @@ namespace DragonFruit.OnionFruit.Models
         /// </summary>
         public TorSessionState State
         {
-            get => _state;
+            get;
             private set
             {
-                if (_state == value) return;
+                if (field == value) return;
 
-                _state = value;
+                field = value;
                 SessionStateChanged?.Invoke(this, value);
             }
-        }
+        } = TorSessionState.Disconnected;
 
         /// <summary>
         /// Event fired when the underlying tor process' bootstrap progress changes

--- a/DragonFruit.OnionFruit/Protos/onionfruitcfg.proto
+++ b/DragonFruit.OnionFruit/Protos/onionfruitcfg.proto
@@ -6,22 +6,22 @@ message OnionFruitConfigFile {
 
   string entryCountryCode = 3;
   string exitCountryCode = 4;
-  
+
   bool enableWebsiteLaunchOnConnect = 5;
   bool enableWebsiteLaunchOnDisconnect = 6;
-  
+
   optional string launchWebsiteOnConnect = 7;
   optional string launchWebsiteOnDisconnect = 8;
-  
+
   // indicates the user is behind a firewall that only allows connections on specific ports
   bool limitOutboundConnectionPorts = 9;
-  
+
   // list of ports the user can connect to, used in conjunction with limitOutboundConnectionPorts
   repeated uint32 allowedFirewallPorts = 10;
-  
+
   TRANSPORT_TYPES SelectedTransportType = 11;
   repeated string UserDefinedBridges = 12;
-  
+
   // aka the "killswitch" feature
   bool disconnectOnProxyFailure = 13;
   bool enableErrorReporting = 14;
@@ -30,10 +30,10 @@ message OnionFruitConfigFile {
   optional UPDATE_STREAM clientUpdateStream = 16;
 
   optional int32 maxCircuitIdleTime = 17;
-  
+
   // Whether DNS proxying should be enabled.
   bool enableDnsProxying = 18;
-  
+
   // What pre-defined fallback DNS servers to use.
   FALLBACK_DNS_SERVER_PRESET fallbackDnsServerPreset = 20;
 

--- a/DragonFruit.OnionFruit/ReactiveAppWindow.cs
+++ b/DragonFruit.OnionFruit/ReactiveAppWindow.cs
@@ -22,7 +22,7 @@ namespace DragonFruit.OnionFruit
     /// This is a version of the ReactiveUI <see cref="ReactiveWindow{TViewModel}"/> class modified to support <see cref="AppWindow"/>.
     /// See https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.ReactiveUI/ReactiveWindow.cs for the original implementation.
     /// </remarks>
-    public class ReactiveAppWindow<TViewModel> : AppWindow, IViewFor<TViewModel> where TViewModel : class
+    public class ReactiveAppWindow<TViewModel> : FAAppWindow, IViewFor<TViewModel> where TViewModel : class
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("AvaloniaProperty", "AVP1002", Justification = "Generic avalonia property is expected here.")]
         public static readonly StyledProperty<TViewModel?> ViewModelProperty = AvaloniaProperty.Register<ReactiveWindow<TViewModel>, TViewModel?>(nameof(ViewModel));

--- a/DragonFruit.OnionFruit/Updater/VelopackUpdater.cs
+++ b/DragonFruit.OnionFruit/Updater/VelopackUpdater.cs
@@ -20,9 +20,6 @@ namespace DragonFruit.OnionFruit.Updater
         private Timer _checkTimer;
         private Task _updateTask;
 
-        private OnionFruitUpdaterStatus _status;
-        private int? _downloadProgress;
-
         public VelopackUpdater(UpdateOptions options, ILogger<VelopackUpdater> logger)
         {
             _logger = logger;
@@ -31,10 +28,10 @@ namespace DragonFruit.OnionFruit.Updater
 
         public OnionFruitUpdaterStatus Status
         {
-            get => _status;
+            get;
             private set
             {
-                _status = value;
+                field = value;
                 StatusChanged?.Invoke(this, value);
             }
         }
@@ -43,10 +40,10 @@ namespace DragonFruit.OnionFruit.Updater
 
         public int? DownloadProgress
         {
-            get => _downloadProgress;
+            get;
             private set
             {
-                _downloadProgress = value;
+                field = value;
                 DownloadProgressChanged?.Invoke(this, value);
             }
         }

--- a/DragonFruit.OnionFruit/ViewModels/AboutPageTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/AboutPageTabViewModel.cs
@@ -70,8 +70,8 @@ namespace DragonFruit.OnionFruit.ViewModels
             Task.Run(ReadPackageLicenseFile);
         }
 
-        public IconSource UpdaterIcon => App.GetIcon(LucideIconNames.RefreshCw);
-        public IconSource LicensesIcon => App.GetIcon(LucideIconNames.Scale);
+        public FAIconSource UpdaterIcon => App.GetIcon(LucideIconNames.RefreshCw);
+        public FAIconSource LicensesIcon => App.GetIcon(LucideIconNames.Scale);
 
         public string CurrentUpdaterProgress => _updateProgress.Value;
 

--- a/DragonFruit.OnionFruit/ViewModels/BridgeSettingsTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/BridgeSettingsTabViewModel.cs
@@ -37,9 +37,6 @@ namespace DragonFruit.OnionFruit.ViewModels
 
         private readonly ReadOnlyObservableCollection<string> _activeTransportBridgeLines;
 
-        private string _newBridgeLines;
-        private bool _showEmptyBridgeListMessage, _showDefaultsPresetMessage;
-
         public BridgeSettingsTabViewModel(OnionFruitSettingsStore settings, TransportManager transports)
         {
             _settings = settings;
@@ -121,8 +118,8 @@ namespace DragonFruit.OnionFruit.ViewModels
         /// </summary>
         public string NewBridgeLines
         {
-            get => _newBridgeLines;
-            set => this.RaiseAndSetIfChanged(ref _newBridgeLines, value);
+            get;
+            set => this.RaiseAndSetIfChanged(ref field, value);
         }
 
         /// <summary>
@@ -130,8 +127,8 @@ namespace DragonFruit.OnionFruit.ViewModels
         /// </summary>
         public bool ShowEmptyBridgeListMessage
         {
-            get => _showEmptyBridgeListMessage;
-            private set => this.RaiseAndSetIfChanged(ref _showEmptyBridgeListMessage, value);
+            get;
+            private set => this.RaiseAndSetIfChanged(ref field, value);
         }
 
         /// <summary>
@@ -139,8 +136,8 @@ namespace DragonFruit.OnionFruit.ViewModels
         /// </summary>
         public bool ShowDefaultsPresetMessage
         {
-            get => _showDefaultsPresetMessage;
-            private set => this.RaiseAndSetIfChanged(ref _showDefaultsPresetMessage, value);
+            get;
+            private set => this.RaiseAndSetIfChanged(ref field, value);
         }
 
         public void AddBridgeLines()

--- a/DragonFruit.OnionFruit/ViewModels/BridgeSettingsTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/BridgeSettingsTabViewModel.cs
@@ -63,7 +63,7 @@ namespace DragonFruit.OnionFruit.ViewModels
                 .Where(x => x != TransportType.None)
                 .Select(x => $"{transports.AvailableTransports[x].Id} 0.0.0.0:12345 AAAAAAABBBBBBBCCCCCCDDDDDDEEEEEEFFFFFF".TrimStart())
                 .ObserveOn(RxSchedulers.MainThreadScheduler)
-                .ToProperty(this, x => x.BridgeLineWatermark)
+                .ToProperty(this, x => x.BridgeLinePlaceholderText)
                 .DisposeWith(_disposables);
 
             settings.GetCollection<string>(OnionFruitSetting.UserDefinedBridges)
@@ -95,7 +95,7 @@ namespace DragonFruit.OnionFruit.ViewModels
         /// <summary>
         /// The watermark shown in the textbox for adding new bridge lines
         /// </summary>
-        public string BridgeLineWatermark => _bridgeLineWatermark.Value;
+        public string BridgeLinePlaceholderText => _bridgeLineWatermark.Value;
 
         /// <summary>
         /// The bridge lines currently in use for the selected transport, displayed in the UI

--- a/DragonFruit.OnionFruit/ViewModels/BridgeSettingsTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/BridgeSettingsTabViewModel.cs
@@ -82,8 +82,8 @@ namespace DragonFruit.OnionFruit.ViewModels
                 .DisposeWith(_disposables);
         }
 
-        public IconSource BridgeTypeIcon => App.GetIcon(LucideIconNames.ChevronsLeftRightEllipsis);
-        public IconSource BridgeLinesIcon => App.GetIcon(LucideIconNames.ScanText);
+        public FAIconSource BridgeTypeIcon => App.GetIcon(LucideIconNames.ChevronsLeftRightEllipsis);
+        public FAIconSource BridgeLinesIcon => App.GetIcon(LucideIconNames.ScanText);
 
         /// <summary>
         /// <see cref="TransportType"/> collection that can be selected by the user

--- a/DragonFruit.OnionFruit/ViewModels/ConnectionSettingsTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/ConnectionSettingsTabViewModel.cs
@@ -162,12 +162,12 @@ namespace DragonFruit.OnionFruit.ViewModels
             RemoveFirewallPort = ReactiveCommand.Create<uint>(RemoveFirewallPortImpl);
         }
 
-        public IconSource DatabaseStateIcon => App.GetIcon(LucideIconNames.DatabaseZap);
-        public IconSource EntryLocationIcon => App.GetIcon(LucideIconNames.LandPlot);
-        public IconSource ExitLocationIcon => App.GetIcon(LucideIconNames.Earth);
-        public IconSource FirewallIcon => App.GetIcon(LucideIconNames.Construction);
-        public IconSource KillswitchIcon => App.GetIcon(LucideIconNames.Unplug);
-        public IconSource CircuitLifetimeIcon => App.GetIcon(LucideIconNames.ClockAlert);
+        public FAIconSource DatabaseStateIcon => App.GetIcon(LucideIconNames.DatabaseZap);
+        public FAIconSource EntryLocationIcon => App.GetIcon(LucideIconNames.LandPlot);
+        public FAIconSource ExitLocationIcon => App.GetIcon(LucideIconNames.Earth);
+        public FAIconSource FirewallIcon => App.GetIcon(LucideIconNames.Construction);
+        public FAIconSource KillswitchIcon => App.GetIcon(LucideIconNames.Unplug);
+        public FAIconSource CircuitLifetimeIcon => App.GetIcon(LucideIconNames.ClockAlert);
 
         /// <summary>
         /// Gets whether the countries database has been loaded and <see cref="TorNodeCountry"/> items have been created.

--- a/DragonFruit.OnionFruit/ViewModels/ConnectionSettingsTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/ConnectionSettingsTabViewModel.cs
@@ -26,8 +26,6 @@ namespace DragonFruit.OnionFruit.ViewModels
         private readonly OnionDbService _database;
         private readonly OnionFruitSettingsStore _settings;
 
-        private ushort? _firewallPortValue;
-
         private readonly CompositeDisposable _disposables = new();
 
         private readonly ObservableAsPropertyHelper<bool> _databaseLoaded;
@@ -212,8 +210,8 @@ namespace DragonFruit.OnionFruit.ViewModels
 
         public ushort? FirewallPort
         {
-            get => _firewallPortValue;
-            set => this.RaiseAndSetIfChanged(ref _firewallPortValue, value);
+            get;
+            set => this.RaiseAndSetIfChanged(ref field, value);
         }
 
         public bool EnableRestrictedFirewallMode

--- a/DragonFruit.OnionFruit/ViewModels/DnsPageTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/DnsPageTabViewModel.cs
@@ -36,8 +36,6 @@ namespace DragonFruit.OnionFruit.ViewModels
 
         private readonly CompositeDisposable _disposables = new();
 
-        private string _customDnsServerEntryContent;
-
         public DnsPageTabViewModel(OnionFruitSettingsStore settings, INetworkAdapterManager adapterManager, IProcessElevator processElevator)
         {
             _settings = settings;
@@ -118,8 +116,8 @@ namespace DragonFruit.OnionFruit.ViewModels
 
         public string CustomDnsServerEntryContent
         {
-            get => _customDnsServerEntryContent;
-            set => this.RaiseAndSetIfChanged(ref _customDnsServerEntryContent, value);
+            get;
+            set => this.RaiseAndSetIfChanged(ref field, value);
         }
 
         public ICommand RelaunchAsElevatedProcess { get; }

--- a/DragonFruit.OnionFruit/ViewModels/DnsPageTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/DnsPageTabViewModel.cs
@@ -81,9 +81,9 @@ namespace DragonFruit.OnionFruit.ViewModels
             RelaunchAsElevatedProcess = ReactiveCommand.Create(() => processElevator.RelaunchProcess(true));
         }
 
-        public IconSource ShieldIcon => App.GetIcon(LucideIconNames.ShieldHalf);
-        public IconSource DnsProxyingIcon => App.GetIcon(LucideIconNames.Waypoints);
-        public IconSource AlternativeServersIcon => App.GetIcon(LucideIconNames.BookDashed);
+        public FAIconSource ShieldIcon => App.GetIcon(LucideIconNames.ShieldHalf);
+        public FAIconSource DnsProxyingIcon => App.GetIcon(LucideIconNames.Waypoints);
+        public FAIconSource AlternativeServersIcon => App.GetIcon(LucideIconNames.BookDashed);
 
         public FALLBACK_DNS_SERVER_PRESET[] AlternativeDnsPresets { get; } = Enum.GetValues<FALLBACK_DNS_SERVER_PRESET>();
 

--- a/DragonFruit.OnionFruit/ViewModels/ExternalConnectionsSettingsTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/ExternalConnectionsSettingsTabViewModel.cs
@@ -63,9 +63,9 @@ namespace DragonFruit.OnionFruit.ViewModels
             SetStartupState = ReactiveCommand.CreateRunInBackground<bool>(SetStartupStateImpl);
         }
 
-        public IconSource DiscordIcon => App.GetIcon(LucideIconNames.Gamepad);
-        public IconSource ErrorIcon => App.GetIcon(LucideIconNames.Bug);
-        public IconSource StartupIcon => App.GetIcon(LucideIconNames.Power);
+        public FAIconSource DiscordIcon => App.GetIcon(LucideIconNames.Gamepad);
+        public FAIconSource ErrorIcon => App.GetIcon(LucideIconNames.Bug);
+        public FAIconSource StartupIcon => App.GetIcon(LucideIconNames.Power);
 
         public bool EnableDiscordRpc
         {

--- a/DragonFruit.OnionFruit/ViewModels/LandingPageSettingsTabViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/LandingPageSettingsTabViewModel.cs
@@ -34,8 +34,8 @@ namespace DragonFruit.OnionFruit.ViewModels
             LaunchUrl = ReactiveCommand.Create<string>(url => App.Launch(string.IsNullOrWhiteSpace(url) ? LandingPageLaunchService.DefaultConnectionPage : url), outputScheduler: RxSchedulers.TaskpoolScheduler);
         }
 
-        public IconSource ConnectedPageIcon => App.GetIcon(LucideIconNames.ShieldCheck);
-        public IconSource DisconnectedPageIcon => App.GetIcon(LucideIconNames.ShieldBan);
+        public FAIconSource ConnectedPageIcon => App.GetIcon(LucideIconNames.ShieldCheck);
+        public FAIconSource DisconnectedPageIcon => App.GetIcon(LucideIconNames.ShieldBan);
 
         public bool EnableConnectedPage
         {

--- a/DragonFruit.OnionFruit/ViewModels/SettingsWindowViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/SettingsWindowViewModel.cs
@@ -21,8 +21,6 @@ namespace DragonFruit.OnionFruit.ViewModels
 
     public class SettingsWindowViewModel : ReactiveObject, IDisposable
     {
-        private SettingsTabInfo _selectedTab;
-
         internal const string AboutTabId = "about";
 
         public SettingsWindowViewModel()
@@ -41,8 +39,8 @@ namespace DragonFruit.OnionFruit.ViewModels
 
         public SettingsTabInfo SelectedTab
         {
-            get => _selectedTab ??= Tabs.FirstOrDefault();
-            set => this.RaiseAndSetIfChanged(ref _selectedTab, value);
+            get => field ??= Tabs.FirstOrDefault();
+            set => this.RaiseAndSetIfChanged(ref field, value);
         }
 
         public IDataTemplate TabTemplate { get; } = new SettingTabViewTemplate();

--- a/DragonFruit.OnionFruit/ViewModels/SettingsWindowViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/SettingsWindowViewModel.cs
@@ -30,7 +30,7 @@ namespace DragonFruit.OnionFruit.ViewModels
                 Tab<ConnectionSettingsTabView, ConnectionSettingsTabViewModel>("Connection", LucideIconNames.EthernetPort),
                 Tab<BridgeSettingsTabView, BridgeSettingsTabViewModel>("Bridges", LucideIconNames.Castle),
                 Tab<DnsPageTabView, DnsPageTabViewModel>("DNS", LucideIconNames.Signpost),
-                Tab<LandingPageSettingsTabView, LandingPageSettingsTabViewModel>("Landing Pages", LucideIconNames.Chrome),
+                Tab<LandingPageSettingsTabView, LandingPageSettingsTabViewModel>("Landing Pages", LucideIconNames.PanelTop),
                 Tab<ExternalConnectionsSettingsTabView, ExternalConnectionsSettingsTabViewModel>("External Connections", LucideIconNames.Sparkles)
             ]);
 

--- a/DragonFruit.OnionFruit/ViewModels/SettingsWindowViewModel.cs
+++ b/DragonFruit.OnionFruit/ViewModels/SettingsWindowViewModel.cs
@@ -17,7 +17,7 @@ using ReactiveUI;
 namespace DragonFruit.OnionFruit.ViewModels
 {
     // XAML can't have nested classes
-    public record SettingsTabInfo(string Id, string Name, IconSource Icon, Func<Control> ContentFactory);
+    public record SettingsTabInfo(string Id, string Name, FAIconSource Icon, Func<Control> ContentFactory);
 
     public class SettingsWindowViewModel : ReactiveObject, IDisposable
     {

--- a/DragonFruit.OnionFruit/Views/MainWindow.axaml
+++ b/DragonFruit.OnionFruit/Views/MainWindow.axaml
@@ -11,7 +11,7 @@
                        x:Class="DragonFruit.OnionFruit.Views.MainWindow"
                        x:DataType="vm:MainWindowViewModel"
                        Background="{x:Null}" Icon="/Assets/icon.ico"
-                       Width="600" Height="175" CanResize="False" Closing="HandleCloseRequest"
+                       Width="600" Height="200" CanResize="False" Closing="HandleCloseRequest"
                        TransparencyLevelHint="{x:Static onionFruit:App.TransparencyLevels}"
                        Title="{Binding Source={x:Static onionFruit:App.Title}}">
     <Design.DataContext>

--- a/DragonFruit.OnionFruit/Views/MainWindow.axaml
+++ b/DragonFruit.OnionFruit/Views/MainWindow.axaml
@@ -1,19 +1,19 @@
-<windowing:AppWindow xmlns="https://github.com/avaloniaui"
-                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                     xmlns:vm="using:DragonFruit.OnionFruit.ViewModels"
-                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                     xmlns:windowing="clr-namespace:FluentAvalonia.UI.Windowing;assembly=FluentAvalonia"
-                     xmlns:onionFruit="clr-namespace:DragonFruit.OnionFruit"
-                     xmlns:controls="clr-namespace:DragonFruit.OnionFruit.Controls"
-                     xmlns:lucideAvalonia="clr-namespace:LucideAvalonia;assembly=LucideAvalonia"
-                     mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="300"
-                     x:Class="DragonFruit.OnionFruit.Views.MainWindow"
-                     x:DataType="vm:MainWindowViewModel"
-                     Background="{x:Null}" Icon="/Assets/icon.ico"
-                     Width="600" Height="175" CanResize="False" Closing="HandleCloseRequest"
-                     TransparencyLevelHint="{x:Static onionFruit:App.TransparencyLevels}"
-                     Title="{Binding Source={x:Static onionFruit:App.Title}}">
+<windowing:FAAppWindow xmlns="https://github.com/avaloniaui"
+                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                       xmlns:vm="using:DragonFruit.OnionFruit.ViewModels"
+                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                       xmlns:windowing="clr-namespace:FluentAvalonia.UI.Windowing;assembly=FluentAvalonia"
+                       xmlns:onionFruit="clr-namespace:DragonFruit.OnionFruit"
+                       xmlns:controls="clr-namespace:DragonFruit.OnionFruit.Controls"
+                       xmlns:lucideAvalonia="clr-namespace:LucideAvalonia;assembly=LucideAvalonia"
+                       mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="300"
+                       x:Class="DragonFruit.OnionFruit.Views.MainWindow"
+                       x:DataType="vm:MainWindowViewModel"
+                       Background="{x:Null}" Icon="/Assets/icon.ico"
+                       Width="600" Height="175" CanResize="False" Closing="HandleCloseRequest"
+                       TransparencyLevelHint="{x:Static onionFruit:App.TransparencyLevels}"
+                       Title="{Binding Source={x:Static onionFruit:App.Title}}">
     <Design.DataContext>
         <vm:MainWindowViewModel />
     </Design.DataContext>
@@ -104,4 +104,4 @@
             </DockPanel>
         </Panel>
     </Window.Content>
-</windowing:AppWindow>
+</windowing:FAAppWindow>

--- a/DragonFruit.OnionFruit/Views/MainWindow.axaml
+++ b/DragonFruit.OnionFruit/Views/MainWindow.axaml
@@ -17,7 +17,7 @@
     <Design.DataContext>
         <vm:MainWindowViewModel />
     </Design.DataContext>
-    
+
     <Window.Styles>
         <Style Selector="Button#MaxRestoreButton">
             <Setter Property="IsVisible" Value="False" />
@@ -40,30 +40,30 @@
                 <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="10" Margin="10" IsVisible="{OnPlatform Default=False, Windows=True}">
                     <TextBlock Text="{Binding WindowTitle}" />
                 </StackPanel>
-                
+
                 <Panel Background="{Binding RibbonContent.Background}" VerticalAlignment="Top" DockPanel.Dock="Top">
                     <DockPanel Margin="20, 10">
                         <ToggleSwitch DockPanel.Dock="Right"
                                       TabIndex="1"
-                                      OnContent="" 
+                                      OnContent=""
                                       OffContent=""
                                       VerticalAlignment="Center"
                                       Command="{Binding ToggleConnection}"
                                       IsChecked="{Binding RibbonContent.ToggleChecked, Mode=OneWay}" />
-                        
+
                         <TextBlock DockPanel.Dock="Left"
                                    TabIndex="0"
                                    FontSize="20"
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"
-                                   Text="{Binding RibbonContent.Text}"/>
+                                   Text="{Binding RibbonContent.Text}" />
                     </DockPanel>
                 </Panel>
-                
+
                 <DockPanel DockPanel.Dock="Top">
                     <DockPanel.Styles>
                         <Style Selector="Control">
-                            <Setter Property="VerticalAlignment" Value="Center"/>
+                            <Setter Property="VerticalAlignment" Value="Center" />
                         </Style>
                     </DockPanel.Styles>
 
@@ -71,36 +71,40 @@
                             Padding="30, 0" CornerRadius="0"
                             Background="Transparent" BorderBrush="Transparent"
                             VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
-                            Command="{Binding OpenSettingsWindow}"/>
+                            Command="{Binding OpenSettingsWindow}" />
 
                     <!-- Country switch, last item fills remaining space -->
-                    <controls:SwitchingControl DockPanel.Dock="Left" Switch="{Binding CountriesDatabaseReady}" Margin="15, 0" VerticalAlignment="Center">
+                    <controls:SwitchingControl DockPanel.Dock="Left"
+                                               Switch="{Binding CountriesDatabaseReady}"
+                                               Margin="15, 0" VerticalAlignment="Center">
                         <controls:SwitchingControl.SwitchFalse>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Spacing="5">
-                                    <lucideAvalonia:Lucide Icon="LoaderPinwheel" StrokeBrush="White" StrokeThickness="2" Width="16" Height="16"/>
+                                    <lucideAvalonia:Lucide Icon="LoaderPinwheel" StrokeBrush="White"
+                                                           StrokeThickness="2" Width="16" Height="16" />
                                     <Label VerticalAlignment="Center">Loading GeoDB...</Label>
                                 </StackPanel>
                             </DataTemplate>
                         </controls:SwitchingControl.SwitchFalse>
                         <controls:SwitchingControl.SwitchTrue>
-                               <DataTemplate x:DataType="vm:MainWindowViewModel">
-                                   <DockPanel>
-                                       <Label DockPanel.Dock="Left" TabIndex="0" VerticalAlignment="Center" Margin="0, 0, 10, 0" Content="Country"/>
-                                       <ComboBox DockPanel.Dock="Left"
-                                                 TabIndex="1"
-                                                 Margin="10, 0, 0, 0"
-                                                 HorizontalAlignment="Stretch"
-                                                 ItemsSource="{Binding ExitCountries}"
-                                                 SelectedValueBinding="{Binding CountryCode}"
-                                                 DisplayMemberBinding="{Binding CountryName}"
-                                                 SelectedValue="{Binding SelectedCountryCode}"
-                                                 IsEnabled="{Binding AllowConfigurationChanges}"/>
-                                   </DockPanel>
-                               </DataTemplate>
+                            <DataTemplate x:DataType="vm:MainWindowViewModel">
+                                <DockPanel>
+                                    <Label DockPanel.Dock="Left" TabIndex="0" VerticalAlignment="Center"
+                                           Margin="0, 0, 10, 0" Content="Country" />
+                                    <ComboBox DockPanel.Dock="Left"
+                                              TabIndex="1"
+                                              Margin="10, 0, 0, 0"
+                                              HorizontalAlignment="Stretch"
+                                              ItemsSource="{Binding ExitCountries}"
+                                              SelectedValueBinding="{Binding CountryCode}"
+                                              DisplayMemberBinding="{Binding CountryName}"
+                                              SelectedValue="{Binding SelectedCountryCode}"
+                                              IsEnabled="{Binding AllowConfigurationChanges}" />
+                                </DockPanel>
+                            </DataTemplate>
                         </controls:SwitchingControl.SwitchTrue>
                     </controls:SwitchingControl>
-                  </DockPanel>
+                </DockPanel>
             </DockPanel>
         </Panel>
     </Window.Content>

--- a/DragonFruit.OnionFruit/Views/MainWindow.axaml.cs
+++ b/DragonFruit.OnionFruit/Views/MainWindow.axaml.cs
@@ -4,7 +4,6 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using DragonFruit.OnionFruit.ViewModels;
 using DragonFruit.OnionFruit.ViewModels.Interfaces;
-using FluentAvalonia.UI.Windowing;
 using Microsoft.Extensions.DependencyInjection;
 using ReactiveUI;
 
@@ -18,8 +17,6 @@ namespace DragonFruit.OnionFruit.Views
 
             // set titlebar options
             TitleBar.ExtendsContentIntoTitleBar = true;
-            TitleBar.TitleBarHitTestType = TitleBarHitTestType.Complex;
-
             TransparencyLevelHint = App.TransparencyLevels;
 
             this.WhenActivated(action => action(ViewModel!.SettingsWindowInteraction.RegisterHandler(OpenSettingsWindow)));
@@ -34,7 +31,10 @@ namespace DragonFruit.OnionFruit.Views
                 viewModel.SetActiveTab(ctx.Input);
             }
 
-            var window = new SettingsWindow() {DataContext = viewModel};
+            var window = new SettingsWindow
+            {
+                DataContext = viewModel
+            };
 
             await window.ShowDialog(this);
             ctx.SetOutput(Unit.Default);

--- a/DragonFruit.OnionFruit/Views/Settings/AboutPageTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/AboutPageTabView.axaml
@@ -19,16 +19,16 @@
             </StackPanel>
         </StackPanel>
 
-        <controls:SettingsExpander Description="Updates" IconSource="{Binding UpdaterIcon, Mode=OneTime}">
-            <controls:SettingsExpander.Footer>
+        <controls:FASettingsExpander Description="Updates" IconSource="{Binding UpdaterIcon, Mode=OneTime}">
+            <controls:FASettingsExpander.Footer>
                 <StackPanel Orientation="Horizontal" Spacing="15">
                     <Label VerticalAlignment="Center" Content="{Binding CurrentUpdaterProgress}"/>
                     <Button VerticalAlignment="Center" Command="{Binding ManualUpdateTrigger}" Content="Check for updates"/>
                 </StackPanel>
-            </controls:SettingsExpander.Footer>
-        </controls:SettingsExpander>
+            </controls:FASettingsExpander.Footer>
+        </controls:FASettingsExpander>
 
-        <controls:SettingsExpander Description="Licenses" IconSource="{Binding LicensesIcon, Mode=OneTime}">
+        <controls:FASettingsExpander Description="Licenses" IconSource="{Binding LicensesIcon, Mode=OneTime}">
             <ItemsControl ItemsSource="{Binding Packages}" Margin="0, 15">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate DataType="models:NugetPackageLicenseInfo">
@@ -77,6 +77,6 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-        </controls:SettingsExpander>
+        </controls:FASettingsExpander>
     </StackPanel>
 </UserControl>

--- a/DragonFruit.OnionFruit/Views/Settings/BridgeSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/BridgeSettingsTabView.axaml
@@ -19,7 +19,7 @@
                     <Setter Property="Margin" Value="0, 0, 15 ,0"/>
                 </Style>
             </StackPanel.Styles>
-            
+
             <controls:FASettingsExpander Description="Bridge Type" IconSource="{Binding BridgeTypeIcon}">
                 <controls:FASettingsExpander.Footer>
                     <ComboBox MinWidth="150"
@@ -46,23 +46,23 @@
                                  TabIndex="0"
                                  DockPanel.Dock="Left"/>
                     </DockPanel>
-                    
+
                     <Border Background="Gray" Height="1" />
-                    
+
                     <StackPanel Orientation="Horizontal" Spacing="15" IsVisible="{Binding ShowEmptyBridgeListMessage}">
                         <lucideAvalonia:Lucide Icon="Info" StrokeBrush="DodgerBlue" Height="20" Width="20"/>
                         <TextBlock VerticalAlignment="Center" TextWrapping="Wrap">
                             No bridge lines have been added yet.
                         </TextBlock>
                     </StackPanel>
-                    
+
                     <StackPanel Orientation="Horizontal" Spacing="15" IsVisible="{Binding ShowDefaultsPresetMessage}">
                         <lucideAvalonia:Lucide Icon="CircleCheck" StrokeBrush="LimeGreen" Height="20" Width="20"/>
                         <TextBlock VerticalAlignment="Center" TextWrapping="Wrap">
                             One or more default entries are automatically provided.
                         </TextBlock>
                     </StackPanel>
-                    
+
                     <ItemsControl ItemsSource="{Binding CurrentBridgeLines}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>

--- a/DragonFruit.OnionFruit/Views/Settings/BridgeSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/BridgeSettingsTabView.axaml
@@ -38,7 +38,7 @@
                     <DockPanel>
                         <Button Content="Add" Command="{Binding AddBridgeLines}" TabIndex="1" DockPanel.Dock="Right"/>
                         <TextBox Text="{Binding NewBridgeLines}"
-                                 Watermark="{Binding BridgeLineWatermark}"
+                                 PlaceholderText="{Binding BridgeLinePlaceholderText}"
                                  FontFamily="{StaticResource JetBrainsMono}"
                                  TextWrapping="NoWrap"
                                  AcceptsReturn="True"

--- a/DragonFruit.OnionFruit/Views/Settings/BridgeSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/BridgeSettingsTabView.axaml
@@ -10,7 +10,7 @@
              x:Class="DragonFruit.OnionFruit.Views.Settings.BridgeSettingsTabView"
              x:DataType="viewModels:BridgeSettingsTabViewModel">
     <StackPanel Orientation="Vertical" MaxWidth="1400" Spacing="10">
-        <controls:NavigationViewItemHeader Content="Bridges"/>
+        <controls:FANavigationViewItemHeader Content="Bridges"/>
 
         <StackPanel Orientation="Vertical" Spacing="10" Margin="15, 20">
             <StackPanel.Styles>
@@ -20,20 +20,20 @@
                 </Style>
             </StackPanel.Styles>
             
-            <controls:SettingsExpander Description="Bridge Type" IconSource="{Binding BridgeTypeIcon}">
-                <controls:SettingsExpander.Footer>
+            <controls:FASettingsExpander Description="Bridge Type" IconSource="{Binding BridgeTypeIcon}">
+                <controls:FASettingsExpander.Footer>
                     <ComboBox MinWidth="150"
                               ItemsSource="{Binding AvailableTransports}"
                               SelectedValue="{Binding SelectedTransport}"
                               DisplayMemberBinding="{Binding Value}"
                               SelectedValueBinding="{Binding Key}"/>
-                </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>
+                </controls:FASettingsExpander.Footer>
+            </controls:FASettingsExpander>
 
-            <controls:SettingsExpander Description="Bridge Lines" IconSource="{Binding BridgeLinesIcon}" IsVisible="{Binding CanAddBridgeLines, Mode=OneWay}" IsExpanded="True" IsClickEnabled="False">
-                <controls:SettingsExpander.Footer>
+            <controls:FASettingsExpander Description="Bridge Lines" IconSource="{Binding BridgeLinesIcon}" IsVisible="{Binding CanAddBridgeLines, Mode=OneWay}" IsExpanded="True" IsClickEnabled="False">
+                <controls:FASettingsExpander.Footer>
                     <Label Content="{Binding CurrentBridgeLineCount, StringFormat='{}{0} Entries'}"/>
-                </controls:SettingsExpander.Footer>
+                </controls:FASettingsExpander.Footer>
                 <StackPanel Orientation="Vertical" Spacing="20" Margin="0,10,0,0">
                     <DockPanel>
                         <Button Content="Add" Command="{Binding AddBridgeLines}" TabIndex="1" DockPanel.Dock="Right"/>
@@ -85,7 +85,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
-            </controls:SettingsExpander>
+            </controls:FASettingsExpander>
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/DragonFruit.OnionFruit/Views/Settings/ConnectionSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/ConnectionSettingsTabView.axaml
@@ -119,7 +119,7 @@
                                MinHeight="35" Width="250"
                                Margin="15,0,0,0"
                                Minimum="1" Maximum="65535" FormatString="0"
-                               PlaceholderText="Allowed Port (1-65535)" VerticalAlignment="Top"
+                               PlaceholderText="Allowed Port (1-65535)" VerticalAlignment="Center"
                                Value="{Binding FirewallPort}">
                     <Interaction.Behaviors>
                         <controls1:EnterKeyBehavior Command="{Binding AddFirewallPort}"/>

--- a/DragonFruit.OnionFruit/Views/Settings/ConnectionSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/ConnectionSettingsTabView.axaml
@@ -56,7 +56,7 @@
             <lucideAvalonia:Lucide Grid.Row="0" Grid.Column="8" Icon="Earth" />
             <Label Grid.Row="1" Grid.Column="8" Content="Internet" />
         </Grid>
-        
+
         <controls:FASettingsExpander IconSource="{Binding DatabaseStateIcon}" Description="Database Status">
             <controls:FASettingsExpander.Footer>
                 <Label Content="{Binding DatabaseState}"/>
@@ -71,7 +71,7 @@
                 </Label>
             </Grid>
         </controls:FASettingsExpander>
-        
+
         <controls1:SwitchingControl Switch="{Binding DatabaseLoaded}">
             <controls1:SwitchingControl.SwitchTrue>
                 <DataTemplate DataType="viewModels:ConnectionSettingsTabViewModel">
@@ -95,7 +95,7 @@
                                 </StackPanel>
                             </controls:FASettingsExpander.Footer>
                         </controls:FASettingsExpander>
-        
+
                         <controls:FASettingsExpander IconSource="{Binding ExitLocationIcon}" Description="Exit Location">
                             <controls:FASettingsExpander.Footer>
                                 <ComboBox MinWidth="200"
@@ -108,7 +108,7 @@
                 </DataTemplate>
             </controls1:SwitchingControl.SwitchTrue>
         </controls1:SwitchingControl>
-        
+
         <controls:FASettingsExpander Description="Restricted Firewall Mode" IconSource="{Binding FirewallIcon}" IsExpanded="{Binding EnableRestrictedFirewallMode, Mode=OneWay}">
             <controls:FASettingsExpander.Footer>
                 <ToggleSwitch OnContent="Enabled" OffContent="Disabled" IsChecked="{Binding EnableRestrictedFirewallMode}"/>
@@ -125,7 +125,7 @@
                         <controls1:EnterKeyBehavior Command="{Binding AddFirewallPort}"/>
                     </Interaction.Behaviors>
                 </NumericUpDown>
-                
+
                 <controls1:SwitchingControl Switch="{Binding ShouldShowFirewallPortList}">
                     <controls1:SwitchingControl.SwitchTrue>
                         <DataTemplate DataType="viewModels:ConnectionSettingsTabViewModel">
@@ -156,7 +156,7 @@
                 </controls1:SwitchingControl>
             </DockPanel>
         </controls:FASettingsExpander>
-        
+
         <controls:FASettingsExpander IconSource="{Binding KillswitchIcon}" Description="Auto-disconnect if Tor is closed externally">
             <controls:FASettingsExpander.Footer>
                 <StackPanel Orientation="Horizontal" Spacing="20">
@@ -171,7 +171,7 @@
                 </StackPanel>
             </controls:FASettingsExpander.Footer>
         </controls:FASettingsExpander>
-        
+
         <controls:FASettingsExpander IconSource="{Binding CircuitLifetimeIcon}" Description="Max circuit inactivity (minutes)">
             <controls:FASettingsExpander.Footer>
                 <NumericUpDown Minimum="5" Maximum="120" Width="200" FormatString="0" Value="{Binding MaxCircuitIdleTime}"/>

--- a/DragonFruit.OnionFruit/Views/Settings/ConnectionSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/ConnectionSettingsTabView.axaml
@@ -119,7 +119,7 @@
                                MinHeight="35" Width="250"
                                Margin="15,0,0,0"
                                Minimum="1" Maximum="65535" FormatString="0"
-                               Watermark="Allowed Port (1-65535)" VerticalAlignment="Top"
+                               PlaceholderText="Allowed Port (1-65535)" VerticalAlignment="Top"
                                Value="{Binding FirewallPort}">
                     <Interaction.Behaviors>
                         <controls1:EnterKeyBehavior Command="{Binding AddFirewallPort}"/>

--- a/DragonFruit.OnionFruit/Views/Settings/ConnectionSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/ConnectionSettingsTabView.axaml
@@ -11,7 +11,7 @@
              x:DataType="viewModels:ConnectionSettingsTabViewModel"
              x:Class="DragonFruit.OnionFruit.Views.Settings.ConnectionSettingsTabView">
     <StackPanel Orientation="Vertical" MaxWidth="1400" Spacing="10">
-        <controls:NavigationViewItemHeader Content="Tor Connection"/>
+        <controls:FANavigationViewItemHeader Content="Tor Connection"/>
 
         <Grid ColumnDefinitions="Auto, *, Auto, .75*, Auto, .75*, Auto, *, Auto" RowDefinitions="*, Auto" Margin="15, 20">
             <Grid.Styles>
@@ -57,10 +57,10 @@
             <Label Grid.Row="1" Grid.Column="8" Content="Internet" />
         </Grid>
         
-        <controls:SettingsExpander IconSource="{Binding DatabaseStateIcon}" Description="Database Status">
-            <controls:SettingsExpander.Footer>
+        <controls:FASettingsExpander IconSource="{Binding DatabaseStateIcon}" Description="Database Status">
+            <controls:FASettingsExpander.Footer>
                 <Label Content="{Binding DatabaseState}"/>
-            </controls:SettingsExpander.Footer>
+            </controls:FASettingsExpander.Footer>
             <Grid ColumnDefinitions="Auto, *" RowDefinitions="*, 10, *" IsVisible="{Binding DatabaseLoaded}">
                 <Label Grid.Row="0" Grid.Column="0">Database Version</Label>
                 <Label Grid.Row="0" Grid.Column="1" Margin="10,0,0,0" Content="{Binding DatabaseVersion, Mode=OneTime}"/>
@@ -70,14 +70,14 @@
                     <TextBlock TextWrapping="WrapWithOverflow" Text="{Binding DatabaseLicense, Mode=OneTime}"/>
                 </Label>
             </Grid>
-        </controls:SettingsExpander>
+        </controls:FASettingsExpander>
         
         <controls1:SwitchingControl Switch="{Binding DatabaseLoaded}">
             <controls1:SwitchingControl.SwitchTrue>
                 <DataTemplate DataType="viewModels:ConnectionSettingsTabViewModel">
                     <StackPanel Orientation="Vertical" Spacing="10">
-                        <controls:SettingsExpander IconSource="{Binding EntryLocationIcon}" Description="Entry Location">
-                            <controls:SettingsExpander.Footer>
+                        <controls:FASettingsExpander IconSource="{Binding EntryLocationIcon}" Description="Entry Location">
+                            <controls:FASettingsExpander.Footer>
                                 <StackPanel Spacing="20" Orientation="Horizontal">
                                     <lucideAvalonia:Lucide Icon="TriangleAlert" StrokeBrush="Orange"
                                                            Height="20" Width="20" IsVisible="{Binding !CanSelectEntryCountry}"
@@ -93,26 +93,26 @@
                                               ItemsSource="{Binding EntryCountries}"
                                               DisplayMemberBinding="{Binding CountryName}" />
                                 </StackPanel>
-                            </controls:SettingsExpander.Footer>
-                        </controls:SettingsExpander>
+                            </controls:FASettingsExpander.Footer>
+                        </controls:FASettingsExpander>
         
-                        <controls:SettingsExpander IconSource="{Binding ExitLocationIcon}" Description="Exit Location">
-                            <controls:SettingsExpander.Footer>
+                        <controls:FASettingsExpander IconSource="{Binding ExitLocationIcon}" Description="Exit Location">
+                            <controls:FASettingsExpander.Footer>
                                 <ComboBox MinWidth="200"
                                           SelectedItem="{Binding SelectedExitCountry}"
                                           ItemsSource="{Binding ExitCountries}"
                                           DisplayMemberBinding="{Binding CountryName}"/>
-                            </controls:SettingsExpander.Footer>
-                        </controls:SettingsExpander>
+                            </controls:FASettingsExpander.Footer>
+                        </controls:FASettingsExpander>
                     </StackPanel>
                 </DataTemplate>
             </controls1:SwitchingControl.SwitchTrue>
         </controls1:SwitchingControl>
         
-        <controls:SettingsExpander Description="Restricted Firewall Mode" IconSource="{Binding FirewallIcon}" IsExpanded="{Binding EnableRestrictedFirewallMode, Mode=OneWay}">
-            <controls:SettingsExpander.Footer>
+        <controls:FASettingsExpander Description="Restricted Firewall Mode" IconSource="{Binding FirewallIcon}" IsExpanded="{Binding EnableRestrictedFirewallMode, Mode=OneWay}">
+            <controls:FASettingsExpander.Footer>
                 <ToggleSwitch OnContent="Enabled" OffContent="Disabled" IsChecked="{Binding EnableRestrictedFirewallMode}"/>
-            </controls:SettingsExpander.Footer>
+            </controls:FASettingsExpander.Footer>
 
             <DockPanel HorizontalAlignment="Right">
                 <NumericUpDown DockPanel.Dock="Right"
@@ -155,10 +155,10 @@
                     </controls1:SwitchingControl.SwitchFalse>
                 </controls1:SwitchingControl>
             </DockPanel>
-        </controls:SettingsExpander>
+        </controls:FASettingsExpander>
         
-        <controls:SettingsExpander IconSource="{Binding KillswitchIcon}" Description="Auto-disconnect if Tor is closed externally">
-            <controls:SettingsExpander.Footer>
+        <controls:FASettingsExpander IconSource="{Binding KillswitchIcon}" Description="Auto-disconnect if Tor is closed externally">
+            <controls:FASettingsExpander.Footer>
                 <StackPanel Orientation="Horizontal" Spacing="20">
                     <lucideAvalonia:Lucide Icon="Info" StrokeBrush="DodgerBlue"
                                            IsVisible="{Binding DisconnectOnTorFailure}"
@@ -169,13 +169,13 @@
                                            ToolTip.Placement="Left"/>
                     <ToggleSwitch IsChecked="{Binding DisconnectOnTorFailure}" OnContent="Enabled" OffContent="Disabled" VerticalAlignment="Center"/>
                 </StackPanel>
-            </controls:SettingsExpander.Footer>
-        </controls:SettingsExpander>
+            </controls:FASettingsExpander.Footer>
+        </controls:FASettingsExpander>
         
-        <controls:SettingsExpander IconSource="{Binding CircuitLifetimeIcon}" Description="Max circuit inactivity (minutes)">
-            <controls:SettingsExpander.Footer>
+        <controls:FASettingsExpander IconSource="{Binding CircuitLifetimeIcon}" Description="Max circuit inactivity (minutes)">
+            <controls:FASettingsExpander.Footer>
                 <NumericUpDown Minimum="5" Maximum="120" Width="200" FormatString="0" Value="{Binding MaxCircuitIdleTime}"/>
-            </controls:SettingsExpander.Footer>
-        </controls:SettingsExpander>
+            </controls:FASettingsExpander.Footer>
+        </controls:FASettingsExpander>
     </StackPanel>
 </UserControl>

--- a/DragonFruit.OnionFruit/Views/Settings/DnsPageTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/DnsPageTabView.axaml
@@ -83,7 +83,7 @@
                             <StackPanel Orientation="Vertical" Spacing="20" Margin="0,10,0,0">
                                 <DockPanel>
                                     <Button Content="Add" Command="{Binding AddDnsServerEntry}" TabIndex="1" DockPanel.Dock="Right"/>
-                                    <TextBox Text="{Binding CustomDnsServerEntryContent}" FontFamily="{StaticResource JetBrainsMono}" Watermark="Enter Server IP (0.0.0.0)" TabIndex="0" DockPanel.Dock="Left">
+                                    <TextBox Text="{Binding CustomDnsServerEntryContent}" FontFamily="{StaticResource JetBrainsMono}" PlaceholderText="Enter Server IP (0.0.0.0)" TabIndex="0" DockPanel.Dock="Left">
                                         <Interaction.Behaviors>
                                             <controls1:EnterKeyBehavior Command="{Binding AddDnsServerEntry}"/>
                                         </Interaction.Behaviors>

--- a/DragonFruit.OnionFruit/Views/Settings/DnsPageTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/DnsPageTabView.axaml
@@ -11,7 +11,7 @@
              x:Class="DragonFruit.OnionFruit.Views.Settings.DnsPageTabView"
              x:DataType="viewModels:DnsPageTabViewModel">
     <StackPanel Orientation="Vertical" MaxWidth="1400" Spacing="10">
-        <controls:NavigationViewItemHeader Content="DNS" />
+        <controls:FANavigationViewItemHeader Content="DNS" />
         
         <StackPanel Orientation="Vertical" Spacing="10" Margin="15, 20">
             <StackPanel.Styles>
@@ -22,8 +22,8 @@
             </StackPanel.Styles>
 
             <!-- process elevation required alert -->
-            <controls:SettingsExpander IsVisible="{Binding ShowMissingPermissionsNotice}" IconSource="{Binding ShieldIcon}" Description="OnionFruit™ needs to be run as an administrator to use DNS features.">
-                <controls:SettingsExpander.Resources>
+            <controls:FASettingsExpander IsVisible="{Binding ShowMissingPermissionsNotice}" IconSource="{Binding ShieldIcon}" Description="OnionFruit™ needs to be run as an administrator to use DNS features.">
+                <controls:FASettingsExpander.Resources>
                     <ResourceDictionary>
                         <ResourceDictionary.MergedDictionaries>
                             <ResourceDictionary>
@@ -31,18 +31,18 @@
                             </ResourceDictionary>
                         </ResourceDictionary.MergedDictionaries>
                     </ResourceDictionary>
-                </controls:SettingsExpander.Resources>
-                <controls:SettingsExpander.Header>
+                </controls:FASettingsExpander.Resources>
+                <controls:FASettingsExpander.Header>
                     <TextBlock Text="Relaunch Required" Margin="{OnPlatform Default='0,0,0,5', Windows='0'}" FontSize="16" Foreground="White"/>
-                </controls:SettingsExpander.Header>
-                <controls:SettingsExpander.Footer>
+                </controls:FASettingsExpander.Header>
+                <controls:FASettingsExpander.Footer>
                     <Button Command="{Binding RelaunchAsElevatedProcess}" Content="Relaunch"/>
-                </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>
+                </controls:FASettingsExpander.Footer>
+            </controls:FASettingsExpander>
             
             <!-- service not available alert -->
-            <controls:SettingsExpander IsVisible="{Binding ShowNotAvailableNotice}" IconSource="{Binding ShieldIcon}" Description="DNS proxying is not available on this operating system.">
-                <controls:SettingsExpander.Resources>
+            <controls:FASettingsExpander IsVisible="{Binding ShowNotAvailableNotice}" IconSource="{Binding ShieldIcon}" Description="DNS proxying is not available on this operating system.">
+                <controls:FASettingsExpander.Resources>
                     <ResourceDictionary>
                         <ResourceDictionary.MergedDictionaries>
                             <ResourceDictionary>
@@ -50,22 +50,22 @@
                             </ResourceDictionary>
                         </ResourceDictionary.MergedDictionaries>
                     </ResourceDictionary>
-                </controls:SettingsExpander.Resources>
-                <controls:SettingsExpander.Header>
+                </controls:FASettingsExpander.Resources>
+                <controls:FASettingsExpander.Header>
                     <TextBlock Text="Feature Unavailable" Margin="{OnPlatform Default='0,0,0,5', Windows='0'}" FontSize="16" Foreground="White"/>
-                </controls:SettingsExpander.Header>
-            </controls:SettingsExpander>
+                </controls:FASettingsExpander.Header>
+            </controls:FASettingsExpander>
             
-            <controls:SettingsExpander Description="DNS Proxying" IconSource="{Binding DnsProxyingIcon}">
-                <controls:SettingsExpander.Footer>
+            <controls:FASettingsExpander Description="DNS Proxying" IconSource="{Binding DnsProxyingIcon}">
+                <controls:FASettingsExpander.Footer>
                     <ToggleSwitch IsChecked="{Binding DnsProxyEnabled}" IsEnabled="{Binding CanToggleDns}" OnContent="Enabled" OffContent="Disabled"/>
-                </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>
+                </controls:FASettingsExpander.Footer>
+            </controls:FASettingsExpander>
 
-            <controls:SettingsExpander Description="Alternative Servers" IconSource="{Binding AlternativeServersIcon}" IsVisible="{Binding !ShowNotAvailableNotice}" IsExpanded="{Binding IsCustomAlternativeDnsServerSelected}">
-                <controls:SettingsExpander.Footer>
+            <controls:FASettingsExpander Description="Alternative Servers" IconSource="{Binding AlternativeServersIcon}" IsVisible="{Binding !ShowNotAvailableNotice}" IsExpanded="{Binding IsCustomAlternativeDnsServerSelected}">
+                <controls:FASettingsExpander.Footer>
                     <ComboBox MinWidth="200" SelectedItem="{Binding SelectedAlternativeDnsServerPreset}" ItemsSource="{Binding AlternativeDnsPresets}"/>
-                </controls:SettingsExpander.Footer>
+                </controls:FASettingsExpander.Footer>
 
                 <controls1:SwitchingControl Switch="{Binding IsCustomAlternativeDnsServerSelected}">
                     <controls1:SwitchingControl.SwitchFalse>
@@ -99,11 +99,11 @@
                                     </TextBlock>
                                 </StackPanel>
 
-                                <controls:ItemsRepeater ItemsSource="{Binding AlternativeDnsServers}">
-                                    <controls:ItemsRepeater.Layout>
-                                        <controls:StackLayout Spacing="15"/>
-                                    </controls:ItemsRepeater.Layout>
-                                    <controls:ItemsRepeater.ItemTemplate>
+                                <controls:FAItemsRepeater ItemsSource="{Binding AlternativeDnsServers}">
+                                    <controls:FAItemsRepeater.Layout>
+                                        <controls:FAStackLayout Spacing="15"/>
+                                    </controls:FAItemsRepeater.Layout>
+                                    <controls:FAItemsRepeater.ItemTemplate>
                                         <DataTemplate DataType="system:String">
                                             <Grid ColumnDefinitions="*, 10, 30" VerticalAlignment="Center">
                                                 <TextBlock Grid.Column="0" 
@@ -111,18 +111,18 @@
                                                            Text="{Binding}"
                                                            VerticalAlignment="Center"
                                                            FontFamily="{StaticResource JetBrainsMono}"/>
-                                                <Button Grid.Column="2" Command="{Binding $parent[controls:ItemsRepeater].((viewModels:DnsPageTabViewModel)DataContext).RemoveDnsServerEntry}" CommandParameter="{Binding}">
+                                                <Button Grid.Column="2" Command="{Binding $parent[controls:FAItemsRepeater].((viewModels:DnsPageTabViewModel)DataContext).RemoveDnsServerEntry}" CommandParameter="{Binding}">
                                                     <lucideAvalonia:Lucide Icon="Trash" StrokeBrush="OrangeRed" Height="15" Width="15" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                                 </Button>
                                             </Grid>
                                         </DataTemplate>
-                                    </controls:ItemsRepeater.ItemTemplate>
-                                </controls:ItemsRepeater>
+                                    </controls:FAItemsRepeater.ItemTemplate>
+                                </controls:FAItemsRepeater>
                             </StackPanel>
                         </DataTemplate>
                     </controls1:SwitchingControl.SwitchTrue>
                 </controls1:SwitchingControl>
-            </controls:SettingsExpander>
+            </controls:FASettingsExpander>
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/DragonFruit.OnionFruit/Views/Settings/DnsPageTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/DnsPageTabView.axaml
@@ -12,7 +12,7 @@
              x:DataType="viewModels:DnsPageTabViewModel">
     <StackPanel Orientation="Vertical" MaxWidth="1400" Spacing="10">
         <controls:FANavigationViewItemHeader Content="DNS" />
-        
+
         <StackPanel Orientation="Vertical" Spacing="10" Margin="15, 20">
             <StackPanel.Styles>
                 <Style Selector="TextBox">
@@ -39,7 +39,7 @@
                     <Button Command="{Binding RelaunchAsElevatedProcess}" Content="Relaunch"/>
                 </controls:FASettingsExpander.Footer>
             </controls:FASettingsExpander>
-            
+
             <!-- service not available alert -->
             <controls:FASettingsExpander IsVisible="{Binding ShowNotAvailableNotice}" IconSource="{Binding ShieldIcon}" Description="DNS proxying is not available on this operating system.">
                 <controls:FASettingsExpander.Resources>
@@ -55,7 +55,7 @@
                     <TextBlock Text="Feature Unavailable" Margin="{OnPlatform Default='0,0,0,5', Windows='0'}" FontSize="16" Foreground="White"/>
                 </controls:FASettingsExpander.Header>
             </controls:FASettingsExpander>
-            
+
             <controls:FASettingsExpander Description="DNS Proxying" IconSource="{Binding DnsProxyingIcon}">
                 <controls:FASettingsExpander.Footer>
                     <ToggleSwitch IsChecked="{Binding DnsProxyEnabled}" IsEnabled="{Binding CanToggleDns}" OnContent="Enabled" OffContent="Disabled"/>

--- a/DragonFruit.OnionFruit/Views/Settings/ExternalConnectionsSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/ExternalConnectionsSettingsTabView.axaml
@@ -9,11 +9,11 @@
              x:Class="DragonFruit.OnionFruit.Views.Settings.ExternalConnectionsSettingsTabView"
              x:DataType="viewModels:ExternalConnectionsSettingsTabViewModel">
     <StackPanel Orientation="Vertical" MaxWidth="1400" Spacing="10">
-        <controls:NavigationViewItemHeader Content="External Connections"/>
+        <controls:FANavigationViewItemHeader Content="External Connections"/>
         
         <StackPanel Orientation="Vertical" Spacing="10" Margin="15, 20">
-            <controls:SettingsExpander Description="Launch on startup" IconSource="{Binding StartupIcon}">
-                <controls:SettingsExpander.Footer>
+            <controls:FASettingsExpander Description="Launch on startup" IconSource="{Binding StartupIcon}">
+                <controls:FASettingsExpander.Footer>
                     <controls1:SwitchingControl Switch="{Binding ForceStartupRepair}">
                         <controls1:SwitchingControl.SwitchFalse>
                             <DataTemplate DataType="viewModels:ExternalConnectionsSettingsTabViewModel">
@@ -36,20 +36,20 @@
                             </DataTemplate>
                         </controls1:SwitchingControl.SwitchTrue>
                     </controls1:SwitchingControl>
-                </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>
+                </controls:FASettingsExpander.Footer>
+            </controls:FASettingsExpander>
 
-            <controls:SettingsExpander Description="Discord status" IconSource="{Binding DiscordIcon}">
-                <controls:SettingsExpander.Footer>
+            <controls:FASettingsExpander Description="Discord status" IconSource="{Binding DiscordIcon}">
+                <controls:FASettingsExpander.Footer>
                     <ToggleSwitch IsChecked="{Binding EnableDiscordRpc}" OnContent="Enabled" OffContent="Disabled"/>
-                </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>
+                </controls:FASettingsExpander.Footer>
+            </controls:FASettingsExpander>
 
-            <controls:SettingsExpander Description="Error reporting" IconSource="{Binding ErrorIcon}">
-                <controls:SettingsExpander.Footer>
+            <controls:FASettingsExpander Description="Error reporting" IconSource="{Binding ErrorIcon}">
+                <controls:FASettingsExpander.Footer>
                     <ToggleSwitch IsChecked="{Binding EnableErrorReporting}" OnContent="Enabled" OffContent="Disabled"/>
-                </controls:SettingsExpander.Footer>
-            </controls:SettingsExpander>
+                </controls:FASettingsExpander.Footer>
+            </controls:FASettingsExpander>
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/DragonFruit.OnionFruit/Views/Settings/ExternalConnectionsSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/ExternalConnectionsSettingsTabView.axaml
@@ -10,7 +10,7 @@
              x:DataType="viewModels:ExternalConnectionsSettingsTabViewModel">
     <StackPanel Orientation="Vertical" MaxWidth="1400" Spacing="10">
         <controls:FANavigationViewItemHeader Content="External Connections"/>
-        
+
         <StackPanel Orientation="Vertical" Spacing="10" Margin="15, 20">
             <controls:FASettingsExpander Description="Launch on startup" IconSource="{Binding StartupIcon}">
                 <controls:FASettingsExpander.Footer>

--- a/DragonFruit.OnionFruit/Views/Settings/LandingPageSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/LandingPageSettingsTabView.axaml
@@ -9,7 +9,7 @@
              x:Class="DragonFruit.OnionFruit.Views.Settings.LandingPageSettingsTabView"
              x:DataType="viewModels:LandingPageSettingsTabViewModel">
     <StackPanel Orientation="Vertical" MaxWidth="1400" Spacing="10">
-        <controls:NavigationViewItemHeader Content="Landing Pages"/>
+        <controls:FANavigationViewItemHeader Content="Landing Pages"/>
 
         <StackPanel Orientation="Vertical" Spacing="10" Margin="15, 20">
             <StackPanel.Styles>
@@ -19,25 +19,25 @@
                 </Style>
             </StackPanel.Styles>
 
-            <controls:SettingsExpander Description="Connected Page" IconSource="{Binding ConnectedPageIcon}" IsExpanded="{Binding EnableConnectedPage, Mode=OneWay}" IsClickEnabled="False">
-                <controls:SettingsExpander.Footer>
+            <controls:FASettingsExpander Description="Connected Page" IconSource="{Binding ConnectedPageIcon}" IsExpanded="{Binding EnableConnectedPage, Mode=OneWay}" IsClickEnabled="False">
+                <controls:FASettingsExpander.Footer>
                     <ToggleSwitch OnContent="Enabled" OffContent="Disabled" IsChecked="{Binding EnableConnectedPage}"/>
-                </controls:SettingsExpander.Footer>
+                </controls:FASettingsExpander.Footer>
                 <DockPanel IsEnabled="{Binding EnableConnectedPage}">
                     <Button DockPanel.Dock="Right" Content="Open" CommandParameter="{Binding ConnectedPage}" Command="{Binding LaunchUrl}"/>
                     <TextBox DockPanel.Dock="Left" MinWidth="300" Text="{Binding ConnectedPage}" Watermark="{Binding Source={x:Static services:LandingPageLaunchService.DefaultConnectionPage}}"/>
                 </DockPanel>
-            </controls:SettingsExpander>
+            </controls:FASettingsExpander>
             
-            <controls:SettingsExpander Description="Disconnected Page" IconSource="{Binding DisconnectedPageIcon}" IsExpanded="{Binding EnableDisconnectedPage, Mode=OneWay}" IsClickEnabled="False">
-                <controls:SettingsExpander.Footer>
+            <controls:FASettingsExpander Description="Disconnected Page" IconSource="{Binding DisconnectedPageIcon}" IsExpanded="{Binding EnableDisconnectedPage, Mode=OneWay}" IsClickEnabled="False">
+                <controls:FASettingsExpander.Footer>
                     <ToggleSwitch OnContent="Enabled" OffContent="Disabled" IsChecked="{Binding EnableDisconnectedPage}"/>
-                </controls:SettingsExpander.Footer>
+                </controls:FASettingsExpander.Footer>
                 <DockPanel IsEnabled="{Binding EnableDisconnectedPage}">
                     <Button DockPanel.Dock="Right" Content="Open" CommandParameter="{Binding DisconnectedPage}" Command="{Binding LaunchUrl}"/>
                     <TextBox DockPanel.Dock="Left" MinWidth="300" Text="{Binding DisconnectedPage}" Watermark="{Binding Source={x:Static services:LandingPageLaunchService.DefaultConnectionPage}}"/>
                 </DockPanel>
-            </controls:SettingsExpander>
+            </controls:FASettingsExpander>
 
             <TextBlock TextWrapping="WrapWithOverflow" FontSize="13" HorizontalAlignment="Right" Margin="0, 10, 0, 0">
                 Landing Pages will be opened by the default system browser.

--- a/DragonFruit.OnionFruit/Views/Settings/LandingPageSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/LandingPageSettingsTabView.axaml
@@ -28,7 +28,7 @@
                     <TextBox DockPanel.Dock="Left" MinWidth="300" Text="{Binding ConnectedPage}" PlaceholderText="{Binding Source={x:Static services:LandingPageLaunchService.DefaultConnectionPage}}"/>
                 </DockPanel>
             </controls:FASettingsExpander>
-            
+
             <controls:FASettingsExpander Description="Disconnected Page" IconSource="{Binding DisconnectedPageIcon}" IsExpanded="{Binding EnableDisconnectedPage, Mode=OneWay}" IsClickEnabled="False">
                 <controls:FASettingsExpander.Footer>
                     <ToggleSwitch OnContent="Enabled" OffContent="Disabled" IsChecked="{Binding EnableDisconnectedPage}"/>

--- a/DragonFruit.OnionFruit/Views/Settings/LandingPageSettingsTabView.axaml
+++ b/DragonFruit.OnionFruit/Views/Settings/LandingPageSettingsTabView.axaml
@@ -25,7 +25,7 @@
                 </controls:FASettingsExpander.Footer>
                 <DockPanel IsEnabled="{Binding EnableConnectedPage}">
                     <Button DockPanel.Dock="Right" Content="Open" CommandParameter="{Binding ConnectedPage}" Command="{Binding LaunchUrl}"/>
-                    <TextBox DockPanel.Dock="Left" MinWidth="300" Text="{Binding ConnectedPage}" Watermark="{Binding Source={x:Static services:LandingPageLaunchService.DefaultConnectionPage}}"/>
+                    <TextBox DockPanel.Dock="Left" MinWidth="300" Text="{Binding ConnectedPage}" PlaceholderText="{Binding Source={x:Static services:LandingPageLaunchService.DefaultConnectionPage}}"/>
                 </DockPanel>
             </controls:FASettingsExpander>
             
@@ -35,7 +35,7 @@
                 </controls:FASettingsExpander.Footer>
                 <DockPanel IsEnabled="{Binding EnableDisconnectedPage}">
                     <Button DockPanel.Dock="Right" Content="Open" CommandParameter="{Binding DisconnectedPage}" Command="{Binding LaunchUrl}"/>
-                    <TextBox DockPanel.Dock="Left" MinWidth="300" Text="{Binding DisconnectedPage}" Watermark="{Binding Source={x:Static services:LandingPageLaunchService.DefaultConnectionPage}}"/>
+                    <TextBox DockPanel.Dock="Left" MinWidth="300" Text="{Binding DisconnectedPage}" PlaceholderText="{Binding Source={x:Static services:LandingPageLaunchService.DefaultConnectionPage}}"/>
                 </DockPanel>
             </controls:FASettingsExpander>
 

--- a/DragonFruit.OnionFruit/Views/SettingsWindow.axaml
+++ b/DragonFruit.OnionFruit/Views/SettingsWindow.axaml
@@ -25,25 +25,26 @@
             </ExperimentalAcrylicBorder>
 
             <DockPanel>
-                <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="10" Margin="10" IsVisible="{OnPlatform Default=False, Windows=True}">
+                <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="10" Margin="10"
+                            IsVisible="{OnPlatform Default=False, Windows=True}">
                     <TextBlock Text="OnionFruit™ Settings" />
                 </StackPanel>
 
-                <controls:NavigationView ContentTemplate="{Binding TabTemplate}"
-                                         MenuItemsSource="{Binding Tabs}"
-                                         FooterMenuItemsSource="{Binding FooterTabs}"
-                                         SelectedItem="{Binding SelectedTab}"
-                                         Content="{Binding SelectedTab}"
-                                         PaneDisplayMode="Auto"
-                                         IsBackButtonVisible="False"
-                                         IsSettingsVisible="False"
-                                         OpenPaneLength="225">
-                    <controls:NavigationView.MenuItemTemplate>
+                <controls:FANavigationView ContentTemplate="{Binding TabTemplate}"
+                                           MenuItemsSource="{Binding Tabs}"
+                                           FooterMenuItemsSource="{Binding FooterTabs}"
+                                           SelectedItem="{Binding SelectedTab}"
+                                           Content="{Binding SelectedTab}"
+                                           PaneDisplayMode="Auto"
+                                           IsBackButtonVisible="False"
+                                           IsSettingsVisible="False"
+                                           OpenPaneLength="225">
+                    <controls:FANavigationView.MenuItemTemplate>
                         <DataTemplate DataType="{x:Type viewModels:SettingsTabInfo}">
-                            <controls:NavigationViewItem Content="{Binding Name}" IconSource="{Binding Icon}" />
+                            <controls:FANavigationViewItem Content="{Binding Name}" IconSource="{Binding Icon}" />
                         </DataTemplate>
-                    </controls:NavigationView.MenuItemTemplate>
-                </controls:NavigationView>
+                    </controls:FANavigationView.MenuItemTemplate>
+                </controls:FANavigationView>
             </DockPanel>
         </Panel>
     </Window.Content>

--- a/DragonFruit.OnionFruit/Views/SettingsWindow.axaml
+++ b/DragonFruit.OnionFruit/Views/SettingsWindow.axaml
@@ -1,17 +1,17 @@
-﻿<windowing:AppWindow xmlns="https://github.com/avaloniaui"
-                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                     xmlns:windowing="clr-namespace:FluentAvalonia.UI.Windowing;assembly=FluentAvalonia"
-                     xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
-                     xmlns:viewModels="clr-namespace:DragonFruit.OnionFruit.ViewModels"
-                     xmlns:onionFruit="clr-namespace:DragonFruit.OnionFruit"
-                     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-                     x:Class="DragonFruit.OnionFruit.Views.SettingsWindow"
-                     x:DataType="viewModels:SettingsWindowViewModel"
-                     Background="{x:Null}" Icon="/Assets/icon.ico"
-                     Height="600" Width="1200" MinHeight="400" MinWidth="650"
-                     Title="{Binding Source={x:Static onionFruit:App.Title}, StringFormat='{}{0} Settings'}">
+﻿<windowing:FAAppWindow xmlns="https://github.com/avaloniaui"
+                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                       xmlns:windowing="clr-namespace:FluentAvalonia.UI.Windowing;assembly=FluentAvalonia"
+                       xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+                       xmlns:viewModels="clr-namespace:DragonFruit.OnionFruit.ViewModels"
+                       xmlns:onionFruit="clr-namespace:DragonFruit.OnionFruit"
+                       mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                       x:Class="DragonFruit.OnionFruit.Views.SettingsWindow"
+                       x:DataType="viewModels:SettingsWindowViewModel"
+                       Background="{x:Null}" Icon="/Assets/icon.ico"
+                       Height="600" Width="1200" MinHeight="400" MinWidth="650"
+                       Title="{Binding Source={x:Static onionFruit:App.Title}, StringFormat='{}{0} Settings'}">
     <Window.Content>
         <Panel>
             <ExperimentalAcrylicBorder IsHitTestVisible="False">
@@ -47,5 +47,4 @@
             </DockPanel>
         </Panel>
     </Window.Content>
-
-</windowing:AppWindow>
+</windowing:FAAppWindow>

--- a/DragonFruit.OnionFruit/Views/SettingsWindow.axaml.cs
+++ b/DragonFruit.OnionFruit/Views/SettingsWindow.axaml.cs
@@ -11,16 +11,14 @@ using FluentAvalonia.UI.Windowing;
 
 namespace DragonFruit.OnionFruit.Views
 {
-    public partial class SettingsWindow : AppWindow
+    public partial class SettingsWindow : FAAppWindow
     {
         public SettingsWindow()
         {
             InitializeComponent();
 
             TransparencyLevelHint = App.TransparencyLevels;
-
             TitleBar.ExtendsContentIntoTitleBar = true;
-            TitleBar.TitleBarHitTestType = TitleBarHitTestType.Complex;
         }
 
         protected override void OnUnloaded(RoutedEventArgs e)


### PR DESCRIPTION
Upgrades Avalonia and UI-adjacent packages to v12:

- Avalonia itself
	- Font rendering seems to be fixed so the connection status now shows as semibold 🎉 
	- #81 can be closed as `0.92.0` is pulled in after this update
- FluentAvaloniaUI (latest beta, should be stable release soon)
	- All components have been prefixed with `FA`, so a lot of the diff is refactoring to reflect this	
- LucideAvalonia - made a fork with v12 support and updated icons. PR for the version fix was put up [here](https://github.com/MarwanFr/LucideAvaloniaUI/pull/12) but haven't gotten a response within a week of posting it.
	- The chrome icon changed to chromium, and now doesn't exist at all. I have gone with `PanelTop` which looks similar to an app window.